### PR TITLE
hosts-file role

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,4 +4,5 @@ forks=16
 host_key_checking=False
 record_host_keys=False
 roles_path=roles:../roles:../../roles
+filter_plugins=filter_plugins:../filter_plugins:../../filter_plugins
 

--- a/doc/hosts-file.md
+++ b/doc/hosts-file.md
@@ -1,0 +1,36 @@
+
+### hosts-file
+Populates the `/etc/hosts` file with entires for multiple hosts
+
+The `hosts-file` role populates the `/etc/hosts` file of each host with entries
+that allow for each host to refer to each other by their host names and, if
+present, their fully qualified domain name.
+
+#### Variables
+
+|Name                    |Default   |Description                                        |
+|:-----------------------|:--------:|:--------------------------------------------------|
+|extra_entries           |`{}`      |mapping of IP addresses to host aliases            |
+|hosts_file_ansible_group|(required)|ansible group name for the nodes to be included    |
+|hosts_file_net_interface|eth0      |network interface from which to sample IP addresses|
+|state                   |present   |state of the specified entries                     |
+
+#### Notes
+
+  - `state` can be "absent", or "present".
+
+#### Examples
+
+Populate the hosts file on every host in the inventory with entries referring to
+each other by host name and, if present, fully qualified domain name.  Also add
+an extra entry for a fake host.
+```YAML
+  - hosts: all
+    roles:
+      - role: hosts-file
+        hosts_file_ansible_group: all
+        extra_entries:
+            "1.2.3.4":
+                - bogus.website.com
+```
+

--- a/doc/hosts-file.md
+++ b/doc/hosts-file.md
@@ -4,33 +4,75 @@ Populates the `/etc/hosts` file with entires for multiple hosts
 
 The `hosts-file` role populates the `/etc/hosts` file of each host with entries
 that allow for each host to refer to each other by their host names and, if
-present, their fully qualified domain name.
+present, their fully qualified domain names.
 
 #### Variables
 
-|Name                    |Default   |Description                                        |
-|:-----------------------|:--------:|:--------------------------------------------------|
-|extra_entries           |`{}`      |mapping of IP addresses to host aliases            |
-|hosts_file_ansible_group|(required)|ansible group name for the nodes to be included    |
-|hosts_file_net_interface|eth0      |network interface from which to sample IP addresses|
-|state                   |present   |state of the specified entries                     |
+|Name                          |Default   |Description                                                          |
+|:-----------------------------|:--------:|:--------------------------------------------------------------------|
+|domain                        |""        |domain name                                                          |
+|extra_clear_entries           |`[]`      |list of host aliases to remove                                       |
+|extra_entries                 |`{}`      |mapping of IP addresses to host aliases                              |
+|local_entries                 |false     |whether to include aliase entries for the local loopback interface   |
+|hosts_file_ansible_group      |(required)|ansible group name for the nodes to be included                      |
+|hosts_file_clear_ansible_group|""        |ansible group name for the nodes whose host aliases are to be removed|
+|hosts_file_net_interface      |eth0      |network interface from which to sample IP addresses                  |
+|state                         |present   |state of the specified entries                                       |
 
 #### Notes
 
+  - If set, `domain` adds additional entries such as
+    `{{ hostname }}.{{ domain }}`.
+
+  - The `extra_clear_entries` and `hosts_file_clear_ansible_group` options
+    define the set of host aliases that should be removed from the hosts file
+    prior to populating it with new entries.  For example, if the hostname of
+    one of the hosts is `myhost` or `myhost` features in `extra_clear_entries`
+    any existing entry in the hosts file that can be used to resolve `myhost`
+    will have the `myhost` host aliase removed before new entries are added.
+
+  - If `local_entries` is set, the same aliases used in the entries for the
+    `hosts_file_net_interface` will also be included in those for the local
+    loopback interface, so that names like `{{ hostname }}` and
+    `{{ hostname }}.{{ domain }}` would resolve to `127.0.0.1` on that host.
+
   - `state` can be "absent", or "present".
+
+  - This role does not overwrite a system's `/etc/hosts` file, but amends it
+    in-place.  Therefore, any preexisting entires in a hosts file should be
+    accounted for since they may cause name resolution behavior to differ from
+    the behavior expected given only the entries created by this role.  Use the
+    `extra_clear_entries` and `hosts_file_clear_ansible_group` options to ensure
+    that any such entries are removed.
 
 #### Examples
 
 Populate the hosts file on every host in the inventory with entries referring to
-each other by host name and, if present, fully qualified domain name.  Also add
-an extra entry for a fake host.
+each other by host name and by fully qualified domain name with "example.com" as
+the domain.  Also add an extra entry for a fake host.
 ```YAML
   - hosts: all
     roles:
       - role: hosts-file
         hosts_file_ansible_group: all
+        domain: example.com
         extra_entries:
             "1.2.3.4":
-                - bogus.website.com
+              - bogus.host.com
+```
+
+Same as above, but ensure that any preexisting entries are removed.
+```YAML
+  - hosts: all
+    roles:
+      - role: hosts-file
+        hosts_file_ansible_group: all
+        hosts_file_clear_ansible_group: all
+        domain: example.com
+        extra_entries:
+            "1.2.3.4":
+              - bogus.host.com
+        extra_clear_entries:
+          - bogus.host.com
 ```
 

--- a/filter_plugins/gobig.py
+++ b/filter_plugins/gobig.py
@@ -1,0 +1,77 @@
+
+def _get_items(x, *items):
+    try:
+        for item in items:
+            if item not in x:
+                return None
+            x = x[item]
+        return x
+    except TypeError:
+        return None
+
+def hosts_file_entries(host_list,
+                       net_interface,
+                       host_vars,
+                       extra_entries,
+                       nodename,
+                       hostname):
+    import itertools as it
+
+    net_interface_key = "ansible_{}".format(net_interface)
+
+    loopback_keys = ["127.0.0.1", "::1"]
+    loopback_entries = [( set(["localhost",
+                               "localhost.localdomain",
+                               "localhost4",
+                               "localhost4.localdomain4",
+                               nodename,
+                               hostname])
+                        | set(extra_entries.get("127.0.0.1", [])) ),
+
+                        ( set(["localhost",
+                             "localhost.localdomain",
+                             "localhost6",
+                             "localhost6.localdomain6",
+                             nodename,
+                             hostname])
+                        | set(extra_entries.get("127.0.0.1", [])) )]
+
+    address_to_host_list = dict(
+        it.chain.from_iterable(
+            filter(lambda x: (x[0] is not None and
+                              x[0] not in loopback_keys),
+                (
+                    (
+                        _get_items(host_vars[host],
+                                   net_interface_key,
+                                   protocol,
+                                   "address"),
+
+                        [host_vars[host]["ansible_hostname"],
+                         host_vars[host]["ansible_nodename"]]
+                    )
+                    for host in host_list
+                )
+            )
+            for protocol in ("ipv4", "ipv6")
+        )
+    )
+
+    host_keys = list(address_to_host_list.keys())
+    host_entries = [( set(address_to_host_list[ip])
+                    | set(extra_entries.get(ip, [])))
+                    for ip in host_keys]
+
+    remaining_keys = list(set(extra_entries.keys()) - ( set(loopback_keys)
+                                                      | set(host_keys)))
+    remaining_entries = [extra_entries[ip] for ip in remaining_keys]
+
+    result = zip(loopback_keys + host_keys + remaining_keys,
+                 map(list, loopback_entries + host_entries + remaining_entries))
+
+    return result
+
+class FilterModule(object):
+    def filters(self):
+        return {"hosts_file_entries": hosts_file_entries}
+

--- a/filter_plugins/shim.py
+++ b/filter_plugins/shim.py
@@ -1,0 +1,9 @@
+
+def regex_escape(string):
+    from re import escape
+    return escape(string)
+
+class FilterModule(object):
+    def filters(self):
+        return {"regex_escape": regex_escape}
+

--- a/playbooks/misc/hosts-file.yml
+++ b/playbooks/misc/hosts-file.yml
@@ -1,0 +1,7 @@
+
+  - hosts: all
+    roles:
+      - role: hosts-file
+        hosts_file_ansible_group: all
+        hosts_file_clear_ansible_group: all
+

--- a/roles/hosts-file/defaults/main.yml
+++ b/roles/hosts-file/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+    extra_entries: {}
+    hosts_file_net_interface: eth0
+    state: present
+

--- a/roles/hosts-file/defaults/main.yml
+++ b/roles/hosts-file/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 
     extra_entries: {}
+    extra_clear_entries: {}
+    local_entries: false
+    domain: ""
     hosts_file_net_interface: eth0
+    hosts_file_clear_ansible_group: ""
     state: present
 

--- a/roles/hosts-file/tasks/main.yml
+++ b/roles/hosts-file/tasks/main.yml
@@ -1,6 +1,35 @@
 ---
 
-  - name: hosts file | update
+  - name: logic flags | compute
+    set_fact:
+        do_clear: >
+            {{ hosts_file_clear_ansible_group != "" }}
+
+  - name: hosts file | probe
+    command: cat /etc/hosts
+    register: hosts_probe
+    when: "{{ do_clear|bool }}"
+
+  - name: hosts file | filter
+    set_fact:
+        filtered_hosts: >
+            {{ hosts_probe.stdout|hosts_file_filter(
+                groups[hosts_file_clear_ansible_group],
+                domain,
+                hostvars,
+                extra_clear_entries,
+                ansible_hostname,
+                ansible_nodename,
+                ansible_fqdn) }}
+    when: "{{ do_clear|bool }}"
+
+  - name: hosts file | clear
+    copy:
+        content: "{{ filtered_hosts }}"
+        dest: /etc/hosts
+    when: "{{ do_clear|bool }}"
+
+  - name: hosts file | amend
     lineinfile:
         dest: /etc/hosts
         regexp: "^{{ item[0]|regex_escape() }}"
@@ -11,8 +40,11 @@
     with_items: >
         {{  groups[hosts_file_ansible_group]
           | hosts_file_entries(hosts_file_net_interface,
+                               domain,
                                hostvars,
                                extra_entries,
+                               local_entries|bool,
+                               ansible_hostname,
                                ansible_nodename,
-                               ansible_hostname) }}
+                               ansible_fqdn) }}
 

--- a/roles/hosts-file/tasks/main.yml
+++ b/roles/hosts-file/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+
+  - name: hosts file | update
+    lineinfile:
+        dest: /etc/hosts
+        regexp: "^{{ item[0]|regex_escape() }}"
+        line: >
+            {{ item[0] }} {{ item[1]|join(" ") }}
+        state: >
+            {{ "present" if item[0] in ("127.0.0.1", "::1") else state }}
+    with_items: >
+        {{  groups[hosts_file_ansible_group]
+          | hosts_file_entries(hosts_file_net_interface,
+                               hostvars,
+                               extra_entries,
+                               ansible_nodename,
+                               ansible_hostname) }}
+


### PR DESCRIPTION
Adds the `hosts-file` utility ansible role.  This role can be used to populate the `/etc/hosts` files of a group of hosts with entries that allow each host to refer to each other by name without the need for DNS services.
