### PR TITLE
AWS environment source script

### DIFF
--- a/dev/aws-env.bash
+++ b/dev/aws-env.bash
@@ -1,0 +1,12 @@
+
+AWS_CREDENTIALS_FILE="$HOME/.aws/credentials"
+
+if [ -f "$AWS_CREDENTIALS_FILE" ] ; then
+    AWS_ACCESS_KEY_ID="$(
+        awk '/aws_access_key/{print $3;}' < "$AWS_CREDENTIALS_FILE" )"
+    AWS_SECRET_ACCESS_KEY="$(
+        awk '/aws_secret_access_key/{print $3;}' < "$AWS_CREDENTIALS_FILE" )"
+    export AWS_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY
+fi
+


### PR DESCRIPTION
Second among a series of PR's.

Adds the file `dev/aws-env.bash` which, when sourced, will set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables based on the contents of the user's `~/.aws/credentials` file (populated using the aws cli).

Initially contains the commits from all prior PR's in the series (will be rebased after they are merged).

New commits: 1
