### PR TITLE
Git cache role

### DIFF
--- a/doc/git-cache.md
+++ b/doc/git-cache.md
@@ -1,0 +1,44 @@
+
+### git-cache
+Maintain a cache of cloned git repos
+
+The `git-cache` role maintains a cache of cloned git repos that it populates
+using the `git` ansible module.  It can be used most places where the `git`
+ansible module would be used with the added benefit of having several additional
+variables set that allow for easy inspection of the details of the repository.
+
+#### Variables
+
+|Name           |Default   |Description                                        |
+|:--------------|:--------:|:--------------------------------------------------|
+|key_file       |""        |ssh key file to use during checkout                |
+|repo           |(required)|url to the git repository to clone                 |
+|state          |present   |state of the repo cache entry                      |
+|variable_prefix|""        |prefix to use for the output variables             |
+|version        |master    |version of the repo to check out                   |
+
+#### Notes
+
+  - `state` can be "absent" or "present".
+  - If defined, an underscore (`_`) is appended to `variable_prefix`.  This role
+    sets the following variables after possibly adding the underscore:
+      - `{{ variable_prefix }}git_hash`: SHA-1 hash of the provided url
+      - `{{ variable_prefix }}git_repo_dir`: path to the `git` directory
+        containing the repository files
+      - `{{ variable_prefix }}git_work_dir`: path to the working copy
+      - `{{ variable_prefix }}git_version`: repository version as reported by
+        `git-describe`
+  - `version` can refer to any branch name, tag name, or SHA-1 hash of any
+    commit.
+
+#### Examples
+
+Clone the gobig repository and prepend the output variable names with "gobig_".
+```YAML
+  - hosts: all
+    roles:
+      - role: git-cache
+        repo: git://github.com/kitware/gobig.git
+        variable_prefix: gobig
+```
+

--- a/playbooks/misc/git-cache.yml
+++ b/playbooks/misc/git-cache.yml
@@ -1,0 +1,7 @@
+
+  - hosts: all
+    roles:
+      - role: git-cache
+        repo: git://github.com/kitware/gobig.git
+        variable_prefix: gobig
+

--- a/roles/git-cache/defaults/main.yml
+++ b/roles/git-cache/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+    version: master
+    key_file: ""
+    variable_prefix: ""
+    state: present
+

--- a/roles/git-cache/tasks/main.yml
+++ b/roles/git-cache/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+
+  - name: logic flags | compute
+    set_fact:
+        do_install: >
+            {{ state == "present" }}
+        remove_repo: >
+            {{ state == "absent" }}
+
+  - name: git | install
+    apt: name=git state=present update_cache=yes
+    when: do_install|bool
+
+  - name: variable prefix | set
+    set_fact:
+        real_variable_prefix: >
+            {{ variable_prefix + "_" if variable_prefix else "" }}
+
+  - name: hash | compute
+    set_fact: git_hash={{ repo|hash("sha1") }}
+
+  - name: paths | compute
+    set_fact:
+        git_repo_path: /repo/{{ git_hash }}/git
+        git_work_path: /repo/{{ git_hash }}/work
+
+  - name: repo path | probe
+    stat:
+        path: "{{ git_repo_path }}"
+    register: repo_probe
+
+  - name: repo path | flag | compute
+    set_fact:
+        do_link: >
+            {{ (do_install|bool) and (not (repo_probe.stat.exists|bool)) }}
+
+  - name: repo | delete
+    file:
+        path: "{{ item }}"
+        state: absent
+    with_items:
+        - "{{ git_work_path }}"
+        - "{{ git_repo_path }}"
+    when: remove_repo|bool
+
+  - name: repo | clone
+    git:
+        accept_hostkey: yes
+        dest: "{{ git_work_path }}"
+        key_file: "{{ key_file }}"
+        repo: "{{ repo }}"
+        version: "{{ version }}"
+    when: do_install|bool
+
+  - name: repo | git dir | relink
+    shell: >
+        mv "{{ git_work_path }}/.git" "{{ git_repo_path }}" &&
+        ln -s "{{ git_repo_path }}" "{{ git_work_path }}/.git"
+    when: do_link|bool
+
+  - name: repo | version spec | probe
+    shell: git describe --tags 2>/dev/null || echo untagged
+    args:
+        chdir: "{{ git_work_path }}"
+    register: version_spec_probe
+    when: do_install|bool
+
+  - name: repo | output variables | set
+    set_fact: >
+        {{ real_variable_prefix }}git_hash="{{ git_hash }}"
+        {{ real_variable_prefix }}git_repo_dir="{{ git_repo_path }}"
+        {{ real_variable_prefix }}git_work_dir="{{ git_work_path }}"
+        {{ real_variable_prefix }}git_version="{{ version_spec_probe.stdout }}"
+    when: do_install|bool
+


### PR DESCRIPTION
Third among a series of PR's.

Adds a new role: `git-cache`, which can be used to manage a growing cache of git repositories.  Can be used in place of the ansible `git` module for pre-fetching a git repository's working copy before building or copying to some other final location.  Provides additional information (such as the output of `git describe --tags`) that can be used to determine paths during further tasks.

Initially contains the commits from all prior PR's in the series (will be rebased after they are merged).

New commits: 1
