### PR TITLE
Mongodb roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ clusters for HPC and data-intensive applications.
   - [hdfs-datanode](doc/hadoop.md)
   - [mesos-master](doc/mesos.md)
   - [mesos-slave](doc/mesos.md)
+  - [mongodb](doc/mongodb.md)
   - [ssh-key-exchange](doc/ssh-key-exchange.md)
   - [ssh-known-hosts](doc/ssh-known-hosts.md)
   - [upstart](doc/upstart.md)

--- a/doc/mongodb.md
+++ b/doc/mongodb.md
@@ -1,0 +1,35 @@
+
+### mongodb
+Provisions and manages a mongodb node
+
+#### Variables
+
+|Name                 |Default|Description                                     |
+|:--------------------|:-----:|:-----------------------------------------------|
+|mongodb_net_interface|eth0   |interface on which to bind                      |
+|mongodb_port         |27017  |port on which to listen for client connections  |
+|state                |started|state of the service                            |
+
+#### Notes
+
+  - `state` can be any one of "absent", "present", "stopped", "started",
+    "reloaded", or "restarted".
+
+#### Examples
+
+Install/Configure/Start
+```YAML
+  - hosts: mongodb
+    roles:
+      - role: mongodb
+        state: started
+```
+
+Stop/Remove
+```YAML
+  - hosts: mongodb
+    roles:
+      - role: mongodb
+        state: absent
+```
+

--- a/playbooks/gobig/assign-groups.yml
+++ b/playbooks/gobig/assign-groups.yml
@@ -6,6 +6,7 @@
         hdfs_namenodes: namenodes
         mesos_masters: masters
         mesos_slaves: slaves
+        mongodb: mongodb
         spark: spark
         uvcmetrics: uvcmetrics
         zookeepers: zookeepers
@@ -20,6 +21,7 @@
 
         mesos_set: "{{ master_set | union(slave_set) }}"
 
+        mongodb_set: "{{ groups.get(mongodb, []) }}"
         spark_set: "{{ groups.get(spark, []) | union(mesos_set) }}"
         uvcmetrics_set: "{{ groups.get(uvcmetrics, []) }}"
         zookeeper_set: "{{ groups.get(zookeepers, []) | union(mesos_set) }}"
@@ -35,6 +37,7 @@
 
       - group_by: key={{ inventory_hostname in mesos_set      and "MC" or "x" }}
 
+      - group_by: key={{ inventory_hostname in mongodb_set    and "MG" or "x" }}
       - group_by: key={{ inventory_hostname in spark_set      and "SP" or "x" }}
       - group_by: key={{ inventory_hostname in uvcmetrics_set and "UM" or "x" }}
       - group_by: key={{ inventory_hostname in zookeeper_set  and "ZK" or "x" }}

--- a/playbooks/gobig/restart.yml
+++ b/playbooks/gobig/restart.yml
@@ -75,3 +75,8 @@
         mesos_master_ansible_group: MM
         state: restarted
 
+  - hosts: MG
+    roles:
+      - role: mongodb
+        state: restarted
+

--- a/playbooks/gobig/site.yml
+++ b/playbooks/gobig/site.yml
@@ -74,3 +74,9 @@
         zookeeper_ansible_group: ZK
         mesos_master_ansible_group: MM
         state: started
+
+  - hosts: MG
+    roles:
+      - role: mongodb
+        state: started
+

--- a/playbooks/gobig/uninstall.yml
+++ b/playbooks/gobig/uninstall.yml
@@ -35,3 +35,8 @@
         mesos_master_ansible_group: MM
         state: absent
 
+  - hosts: MG
+    roles:
+      - role: mongodb
+        state: absent
+

--- a/playbooks/mongodb/site.yml
+++ b/playbooks/mongodb/site.yml
@@ -1,0 +1,7 @@
+---
+
+  - hosts: mongodb
+    roles:
+      - role: mongodb
+        state: started
+

--- a/playbooks/mongodb/uninstall.yml
+++ b/playbooks/mongodb/uninstall.yml
@@ -1,0 +1,7 @@
+---
+
+  - hosts: mongodb
+    roles:
+      - role: mongodb
+        state: absent
+

--- a/roles/mongodb-install/meta/main.yml
+++ b/roles/mongodb-install/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+  - role: mongodb-variables
+

--- a/roles/mongodb-install/tasks/main.yml
+++ b/roles/mongodb-install/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+
+  - name: install
+    apt:
+        name: "{{ item }}"
+        state: >
+            {{ "present" if (do_install|bool) else "absent" }}
+        update_cache: true
+    with_items:
+      - mongodb
+      - mongodb-server
+    when: do_install|bool
+
+  - name: service | stop
+    service:
+        name: mongodb
+        state: stopped
+    when: do_install|bool
+
+  - name: configure | log file | owner | set
+    file:
+        path: /var/log/mongodb.log
+        state: touch
+        owner: mongodb
+    when: do_install|bool
+
+  - name: configure | old log dir | remove
+    file:
+        path: /var/log/mongodb
+        state: absent
+    when: do_install|bool
+
+  - name: configure
+    template:
+        src: mongodb.conf.j2
+        dest: /etc/mongodb.conf
+    when: do_install|bool
+

--- a/roles/mongodb-install/templates/mongodb.conf.j2
+++ b/roles/mongodb-install/templates/mongodb.conf.j2
@@ -1,0 +1,11 @@
+
+dbpath=/var/lib/mongodb
+logpath=/var/log/mongodb.log
+logappend=true
+bind_ip={{ hostvars[inventory_hostname]
+                   ["ansible_" + mongodb_net_interface]
+                   ["ipv4"]
+                   ["address"] }}
+port={{ mongodb_port }}
+journal=true
+

--- a/roles/mongodb-service/meta/main.yml
+++ b/roles/mongodb-service/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+  - role: mongodb-variables
+

--- a/roles/mongodb-service/tasks/main.yml
+++ b/roles/mongodb-service/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+  - name: mongodb | service
+    service:
+        name: mongodb
+        state: "{{ state }}"
+    when: notify_services|bool
+

--- a/roles/mongodb-variables/defaults/main.yml
+++ b/roles/mongodb-variables/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+    mongodb_net_interface: eth0
+    mongodb_port: 27017
+    state: started
+

--- a/roles/mongodb-variables/tasks/main.yml
+++ b/roles/mongodb-variables/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+
+  - name: mongodb | service | logic flags | compute
+    set_fact:
+        remove_data_root: "{{ state == 'absent' }}"
+        remove_install_root: "{{ state == 'absent' }}"
+        stop_services: "{{ state == 'absent' }}"
+        do_install: >
+            {{ state == "present" or state == "stopped" or
+               state == "started" or state == "restarted" or
+               state == "reloaded" }}
+        notify_services: >
+            {{ state == "stopped" or state == "started"
+            or state == "restarted" or state == "reloaded" }}
+

--- a/roles/mongodb/meta/main.yml
+++ b/roles/mongodb/meta/main.yml
@@ -1,0 +1,7 @@
+---
+
+dependencies:
+  - role: mongodb-variables
+  - role: mongodb-install
+  - role: mongodb-service
+


### PR DESCRIPTION
Fourth among a series of PR's.

Adds a new role: `mongodb`, for provisioning and managing mongodb nodes.

Initially contains the commits from all prior PR's in the series (will be rebased after they are merged).

New commits: 1
