### PR TITLE
Rabbitmq roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ clusters for HPC and data-intensive applications.
   - [mesos-master](doc/mesos.md)
   - [mesos-slave](doc/mesos.md)
   - [mongodb](doc/mongodb.md)
+  - [rabbitmq](doc/rabbitmq.md)
   - [ssh-key-exchange](doc/ssh-key-exchange.md)
   - [ssh-known-hosts](doc/ssh-known-hosts.md)
   - [upstart](doc/upstart.md)

--- a/doc/rabbitmq.md
+++ b/doc/rabbitmq.md
@@ -1,0 +1,34 @@
+
+### rabbitmq
+Provisions and manages a rabbitmq node
+
+#### Variables
+
+|Name                 |Default|Description                                     |
+|:--------------------|:-----:|:-----------------------------------------------|
+|state                |started|state of the service                            |
+
+
+#### Notes
+
+  - `state` can be any one of "absent", "present", "stopped", "started",
+    "reloaded", or "restarted".
+
+#### Examples
+
+Install/Configure/Start
+```YAML
+  - hosts: rabbitmq
+    roles:
+      - role: rabbitmq
+        state: started
+```
+
+Stop/Remove
+```YAML
+  - hosts: rabbitmq
+    roles:
+      - role: rabbitmq
+        state: absent
+```
+

--- a/playbooks/gobig/assign-groups.yml
+++ b/playbooks/gobig/assign-groups.yml
@@ -7,6 +7,7 @@
         mesos_masters: masters
         mesos_slaves: slaves
         mongodb: mongodb
+        rabbitmq: rabbitmq
         spark: spark
         uvcmetrics: uvcmetrics
         zookeepers: zookeepers
@@ -22,6 +23,7 @@
         mesos_set: "{{ master_set | union(slave_set) }}"
 
         mongodb_set: "{{ groups.get(mongodb, []) }}"
+        rabbitmq_set: "{{ groups.get(rabbitmq, []) }}"
         spark_set: "{{ groups.get(spark, []) | union(mesos_set) }}"
         uvcmetrics_set: "{{ groups.get(uvcmetrics, []) }}"
         zookeeper_set: "{{ groups.get(zookeepers, []) | union(mesos_set) }}"
@@ -38,6 +40,7 @@
       - group_by: key={{ inventory_hostname in mesos_set      and "MC" or "x" }}
 
       - group_by: key={{ inventory_hostname in mongodb_set    and "MG" or "x" }}
+      - group_by: key={{ inventory_hostname in rabbitmq_set   and "RQ" or "x" }}
       - group_by: key={{ inventory_hostname in spark_set      and "SP" or "x" }}
       - group_by: key={{ inventory_hostname in uvcmetrics_set and "UM" or "x" }}
       - group_by: key={{ inventory_hostname in zookeeper_set  and "ZK" or "x" }}

--- a/playbooks/gobig/restart.yml
+++ b/playbooks/gobig/restart.yml
@@ -80,3 +80,8 @@
       - role: mongodb
         state: restarted
 
+  - hosts: RQ
+    roles:
+      - role: rabbitmq
+        state: restarted
+

--- a/playbooks/gobig/site.yml
+++ b/playbooks/gobig/site.yml
@@ -80,3 +80,8 @@
       - role: mongodb
         state: started
 
+  - hosts: RQ
+    roles:
+      - role: rabbitmq
+        state: started
+

--- a/playbooks/gobig/uninstall.yml
+++ b/playbooks/gobig/uninstall.yml
@@ -40,3 +40,8 @@
       - role: mongodb
         state: absent
 
+  - hosts: RQ
+    roles:
+      - role: rabbitmq
+        state: absent
+

--- a/playbooks/rabbitmq/site.yml
+++ b/playbooks/rabbitmq/site.yml
@@ -1,0 +1,7 @@
+---
+
+  - hosts: rabbitmq
+    roles:
+      - role: rabbitmq
+        state: started
+

--- a/playbooks/rabbitmq/uninstall.yml
+++ b/playbooks/rabbitmq/uninstall.yml
@@ -1,0 +1,7 @@
+---
+
+  - hosts: rabbitmq
+    roles:
+      - role: rabbitmq
+        state: absent
+

--- a/roles/rabbitmq-install/meta/main.yml
+++ b/roles/rabbitmq-install/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+  - role: rabbitmq-variables
+

--- a/roles/rabbitmq-install/tasks/main.yml
+++ b/roles/rabbitmq-install/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+  - name: install
+    apt:
+        name: rabbitmq-server
+        state: >
+            {{ "present" if (do_install|bool) else "absent" }}
+        update_cache: true
+

--- a/roles/rabbitmq-service/meta/main.yml
+++ b/roles/rabbitmq-service/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+  - role: rabbitmq-variables
+

--- a/roles/rabbitmq-service/tasks/main.yml
+++ b/roles/rabbitmq-service/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+  - name: rabbitmq | service
+    service:
+        name: rabbitmq-server
+        state: "{{ state }}"
+    when: notify_services|bool
+

--- a/roles/rabbitmq-variables/defaults/main.yml
+++ b/roles/rabbitmq-variables/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+    state: started
+

--- a/roles/rabbitmq-variables/tasks/main.yml
+++ b/roles/rabbitmq-variables/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+
+  - name: rabbitmq | service | logic flags | compute
+    set_fact:
+        remove_data_root: "{{ state == 'absent' }}"
+        remove_install_root: "{{ state == 'absent' }}"
+        stop_services: "{{ state == 'absent' }}"
+        do_install: >
+            {{ state == "present" or state == "stopped" or
+               state == "started" or state == "restarted" or
+               state == "reloaded" }}
+        notify_services: >
+            {{ state == "stopped" or state == "started"
+            or state == "restarted" or state == "reloaded" }}
+

--- a/roles/rabbitmq/meta/main.yml
+++ b/roles/rabbitmq/meta/main.yml
@@ -1,0 +1,7 @@
+---
+
+dependencies:
+  - role: rabbitmq-variables
+  - role: rabbitmq-install
+  - role: rabbitmq-service
+


### PR DESCRIPTION
Fifth among a series of PR's.

Adds a new role: `rabbitmq`, for provisioning and managing rabbitmq nodes.

Initially contains the commits from all prior PR's in the series (will be rebased after they are merged).

New commits: 1
