### PR TITLE
Nodejs roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ clusters for HPC and data-intensive applications.
   - [mesos-master](doc/mesos.md)
   - [mesos-slave](doc/mesos.md)
   - [mongodb](doc/mongodb.md)
+  - [nodejs](doc/nodejs.md)
   - [rabbitmq](doc/rabbitmq.md)
   - [ssh-key-exchange](doc/ssh-key-exchange.md)
   - [ssh-known-hosts](doc/ssh-known-hosts.md)

--- a/doc/nodejs.md
+++ b/doc/nodejs.md
@@ -1,0 +1,38 @@
+
+### nodejs
+Installs nodejs from source
+
+#### Variables
+
+|Name               |Default    |Description                                   |
+|:------------------|:---------:|:---------------------------------------------|
+|nodejs_install_root|(generated)|root directory to install nodejs under        |
+|nodejs_version     |v4.0.0     |version of nodejs to install                  |
+|recompile          |false      |whether to force recompilation of nodejs      |
+|state              |present    |state of the software package                 |
+
+#### Notes
+
+  -  The `nodejs_version` value can be any tag, branch, or commit hash from the
+     nodejs github repository.
+
+  - `state` can be either "absent" or "present".
+
+#### Examples
+
+Install/Configure
+```YAML
+  - hosts: nodejs
+    roles:
+      - role: nodejs
+        state: present
+```
+
+Uninstall
+```YAML
+  - hosts: nodejs
+    roles:
+      - role: nodejs
+        state: absent
+```
+

--- a/playbooks/gobig/assign-groups.yml
+++ b/playbooks/gobig/assign-groups.yml
@@ -28,6 +28,8 @@
         uvcmetrics_set: "{{ groups.get(uvcmetrics, []) }}"
         zookeeper_set: "{{ groups.get(zookeepers, []) | union(mesos_set) }}"
 
+        nodejs_set: []
+
     tasks:
       - group_by: key={{ inventory_hostname in datanode_set   and "HD" or "x" }}
       - group_by: key={{ inventory_hostname in namenode_set   and "HN" or "x" }}
@@ -44,4 +46,6 @@
       - group_by: key={{ inventory_hostname in spark_set      and "SP" or "x" }}
       - group_by: key={{ inventory_hostname in uvcmetrics_set and "UM" or "x" }}
       - group_by: key={{ inventory_hostname in zookeeper_set  and "ZK" or "x" }}
+
+      - group_by: key={{ inventory_hostname in nodejs_set     and "NJ" or "x" }}
 

--- a/playbooks/gobig/restart.yml
+++ b/playbooks/gobig/restart.yml
@@ -28,6 +28,11 @@
         user: ubuntu
         ssh_key_exchange_ansible_group: MC
 
+  - hosts: NJ
+    roles:
+      - role: nodejs
+        state: present
+
   - hosts: UM
     roles:
       - role: uvcmetrics

--- a/playbooks/gobig/site.yml
+++ b/playbooks/gobig/site.yml
@@ -28,6 +28,10 @@
         user: ubuntu
         ssh_key_exchange_ansible_group: MC
 
+  - hosts: NJ
+    roles:
+      - role: nodejs
+        state: present
 
   - hosts: UM
     roles:

--- a/playbooks/gobig/uninstall.yml
+++ b/playbooks/gobig/uninstall.yml
@@ -15,6 +15,11 @@
         hdfs_namenode_ansible_group: HN
         state: absent
 
+  - hosts: NJ
+    roles:
+      - role: nodejs
+        state: absent
+
   - hosts: UM
     roles:
       - role: uvcmetrics

--- a/playbooks/nodejs/site.yml
+++ b/playbooks/nodejs/site.yml
@@ -1,0 +1,7 @@
+---
+
+  - hosts: nodejs
+    roles:
+      - role: nodejs
+        state: present
+

--- a/playbooks/nodejs/uninstall.yml
+++ b/playbooks/nodejs/uninstall.yml
@@ -1,0 +1,7 @@
+---
+
+  - hosts: nodejs
+    roles:
+      - role: nodejs
+        state: absent
+

--- a/roles/nodejs-install/meta/main.yml
+++ b/roles/nodejs-install/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+  - role: nodejs-variables
+

--- a/roles/nodejs-install/tasks/main.yml
+++ b/roles/nodejs-install/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+
+  - name: nodejs | deps | install
+    apt: name={{ item }} state=present update_cache=yes
+    with_items:
+      - apt-utils
+      - build-essential
+      - autoconf
+      - libcppunit-dev
+      - libtool
+      - openssh-client
+      - openssh-server
+      - rsync
+      - sudo
+      - tar
+      - gzip
+      - wget
+    when: do_install|bool
+
+  - name: nodejs | install root | delete
+    file:
+        path: "{{ nodejs_install_root }}"
+        state: absent
+    when: remove_install_root|bool
+
+  - name: nodejs | install parent | create
+    file:
+        path: "{{ nodejs_install_parent }}"
+        state: directory
+    when: do_install|bool
+
+  - name: nodejs | source | dir | create
+    file:
+        path: "{{ nodejs_install_root }}/src"
+        state: directory
+    when: create_install_root|bool
+
+  - name: nodejs | repo | sync
+    command: >
+        rsync -avz --exclude=.git
+        "{{ nodejs_git_work_dir }}/"
+        "{{ nodejs_install_root }}/src"
+    when: create_install_root|bool
+
+  - name: nodejs | build | configure
+    shell: >
+        ./configure "--prefix={{ nodejs_install_root }}"
+    args:
+        chdir: "{{ nodejs_install_root }}/src"
+    when: do_compile|bool
+
+  - name: nodejs | build | compile
+    shell: make && make install
+    args:
+        chdir: "{{ nodejs_install_root }}/src"
+    when: do_compile|bool
+
+  - name: nodejs | binaries | rename
+    shell: >
+        mv "{{ item }}" "{{ item }}.real"
+    args:
+        chdir: "{{ nodejs_install_root }}/bin"
+    with_items:
+      - node
+      - npm
+    when: do_compile|bool
+
+  - name: nodejs | env | script | generate
+    template:
+        src: setup-env.bash.j2
+        dest: "{{ nodejs_install_root }}/setup-env.bash"
+        mode: 0644
+    when: do_compile|bool
+
+  - name: nodejs | binaries | wrapper | generate
+    template:
+        src: "{{ item }}.j2"
+        dest: "{{ nodejs_install_root }}/bin/{{ item }}"
+        mode: 0755
+    with_items:
+      - node
+      - npm
+    when: do_compile|bool
+

--- a/roles/nodejs-install/templates/node.j2
+++ b/roles/nodejs-install/templates/node.j2
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+source "{{ nodejs_install_root }}/setup-env.bash"
+"{{ nodejs_install_root }}/bin/node.real" "$@"
+

--- a/roles/nodejs-install/templates/npm.j2
+++ b/roles/nodejs-install/templates/npm.j2
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+source "{{ nodejs_install_root }}/setup-env.bash"
+"{{ nodejs_install_root }}/bin/npm.real" "$@"
+

--- a/roles/nodejs-install/templates/setup-env.bash.j2
+++ b/roles/nodejs-install/templates/setup-env.bash.j2
@@ -1,0 +1,12 @@
+
+export PATH="{{ nodejs_install_root }}/sbin:$PATH"
+export PATH="{{ nodejs_install_root }}/bin:$PATH"
+
+export C_INCLUDE_PATH="{{ nodejs_install_root }}/include:$C_INCLUDE_PATH"
+export CPLUS_INCLUDE_PATH="{{
+    nodejs_install_root }}/include:$CPLUS_INCLUDE_PATH"
+
+export LD_LIBRARY_PATH="{{ nodejs_install_root }}/lib:$LD_LIBRARY_PATH"
+
+export NODE_PATH="{{ nodejs_install_root }}/lib/node_modules:$NODE_PATH"
+

--- a/roles/nodejs-variables/defaults/main.yml
+++ b/roles/nodejs-variables/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+
+    nodejs_version: v4.0.0
+    nodejs_install_root: ""
+
+    state: present
+    recompile: false
+

--- a/roles/nodejs-variables/meta/main.yml
+++ b/roles/nodejs-variables/meta/main.yml
@@ -1,0 +1,9 @@
+---
+
+dependencies:
+  - role: git-cache
+    repo: git://github.com/nodejs/node.git
+    version: "{{ nodejs_version }}"
+    variable_prefix: nodejs
+    state: present
+

--- a/roles/nodejs-variables/tasks/main.yml
+++ b/roles/nodejs-variables/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+
+  - name: nodejs | logic flags | compute
+    set_fact:
+        remove_install_root: "{{ state == 'absent' }}"
+        do_install: >
+            {{ state == "present" }}
+
+  - name: nodejs | install root | default | set
+    set_fact:
+        nodejs_install_root: /opt/nodejs/{{ nodejs_git_version }}
+    when: nodejs_install_root == ""
+
+  - name: nodejs | install root | parent | probe
+    shell: dirname "{{ nodejs_install_root }}"
+    register: parent_probe
+
+  - name: nodejs | install root | parent | record
+    set_fact:
+        nodejs_install_parent: "{{ parent_probe.stdout }}"
+
+  - name: nodejs | install root | probe
+    stat:
+        path: "{{ nodejs_install_root }}"
+    register: install_root_probe
+
+  - name: nodejs | install root | flag | record
+    set_fact:
+        create_install_root: >
+            {{ (do_install|bool) and
+                (not (install_root_probe.stat.exists|bool)) }}
+
+  - name: nodejs | build | probe
+    stat:
+        path: "{{ nodejs_install_root }}/.build"
+    register: build_probe
+
+  - name: nodejs | build | flag | compute
+    set_fact:
+        do_compile: >
+            {{ (do_install|bool) and
+                (not (build_probe.stat.exists|bool) or (recompile|bool)) }}
+
+  - name: nodejs | environment | flags | set
+    set_fact:
+        nodejs_binary: "{{ nodejs_install_root }}/bin/node"
+        npm_binary: "{{ nodejs_install_root }}/bin/npm"
+

--- a/roles/nodejs/meta/main.yml
+++ b/roles/nodejs/meta/main.yml
@@ -1,0 +1,6 @@
+---
+
+dependencies:
+  - role: nodejs-variables
+  - role: nodejs-install
+


### PR DESCRIPTION
Sixth among a series of PRs.

Adds a new role: `nodejs`, for building and installing nodejs from source.  This role offers an alternative to using PPAs or other externally-maintained package offerings for nodejs; one whose successful use is not subject to the state of such offerings.

Initially contains the commits from all prior PRs in the series (will be rebased after they are merged).

New commits: 1
