### PR TITLE
Romanesco roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ clusters for HPC and data-intensive applications.
   - [mongodb](doc/mongodb.md)
   - [nodejs](doc/nodejs.md)
   - [rabbitmq](doc/rabbitmq.md)
+  - [romanesco](doc/romanesco.md)
   - [ssh-key-exchange](doc/ssh-key-exchange.md)
   - [ssh-known-hosts](doc/ssh-known-hosts.md)
   - [upstart](doc/upstart.md)

--- a/doc/romanesco.md
+++ b/doc/romanesco.md
@@ -1,0 +1,58 @@
+
+### romanesco
+Provisions and manages a romanesco node
+
+#### Variables
+
+|Name                      |Default    |Description                                                   |
+|:-------------------------|:---------:|:-------------------------------------------------------------|
+|rabbitmq_ansible_group    |(required) |ansible group name for the rabbitmq nodes                     |
+|romanesco_crypt_pass      |(generated)|hash of the password to use for the user                      |
+|romanesco_data_root       |(generated)|root directory for the romanesco data files                   |
+|romanesco_group           |romanesco  |group to run the romanesco service as                         |
+|romanesco_install_root    |(generated)|root directory to install romanesco under                     |
+|romanesco_net_interface   |eth0       |interface on which to bind                                    |
+|romanesco_version         |master     |version of romanesco to deploy                                |
+|romanesco_user            |romanesco  |user to run the romanesco service as                          |
+|romanesco_main_app_name   |romanesco  |name of the main application to report to celery              |
+|romanesco_celery_broker   |(generated)|broker url for celery                                         |
+|romanesco_tmp_root        |(generated)|root directory for temporary files                            |
+|romanesco_plugin_load_path|(empty)    |list of directories to add to the romanesco plugin search path|
+|state                     |started    |state of the service                                          |
+
+#### Notes
+
+  - `state` can be any one of "absent", "present", "stopped", "started",
+    "reloaded", or "restarted".
+
+  - By default, the hash for a blank password is used when creating
+    a new romanesco user, disabling password login.
+
+  - By default, romanesco is installed under /opt/romanesco/`romanesco-version`.
+
+  - By default, romanesco's data is stored under
+    /data/romanesco/`romanesco-version`.
+
+  - The default celery broker uri is based on the `rabbitmq_ansible_group`
+    value.
+
+#### Examples
+
+Install/Configure/Start
+```YAML
+  - hosts: romanesco
+    roles:
+      - role: romanesco
+        rabbitmq_ansible_group: rabbitmq
+        state: started
+```
+
+Stop/Remove
+```YAML
+  - hosts: romanesco
+    roles:
+      - role: romanesco
+        rabbitmq_ansible_group: rabbitmq
+        state: absent
+```
+

--- a/playbooks/gobig/assign-groups.yml
+++ b/playbooks/gobig/assign-groups.yml
@@ -7,6 +7,7 @@
         mesos_masters: masters
         mesos_slaves: slaves
         mongodb: mongodb
+        romanesco: romanesco
         rabbitmq: rabbitmq
         spark: spark
         uvcmetrics: uvcmetrics
@@ -23,12 +24,13 @@
         mesos_set: "{{ master_set | union(slave_set) }}"
 
         mongodb_set: "{{ groups.get(mongodb, []) }}"
+        romanesco_set: "{{ groups.get(romanesco, []) }}"
         rabbitmq_set: "{{ groups.get(rabbitmq, []) }}"
         spark_set: "{{ groups.get(spark, []) | union(mesos_set) }}"
         uvcmetrics_set: "{{ groups.get(uvcmetrics, []) }}"
         zookeeper_set: "{{ groups.get(zookeepers, []) | union(mesos_set) }}"
 
-        nodejs_set: []
+        nodejs_set: "{{ romanesco_set }}"
 
     tasks:
       - group_by: key={{ inventory_hostname in datanode_set   and "HD" or "x" }}
@@ -42,6 +44,7 @@
       - group_by: key={{ inventory_hostname in mesos_set      and "MC" or "x" }}
 
       - group_by: key={{ inventory_hostname in mongodb_set    and "MG" or "x" }}
+      - group_by: key={{ inventory_hostname in romanesco_set  and "RM" or "x" }}
       - group_by: key={{ inventory_hostname in rabbitmq_set   and "RQ" or "x" }}
       - group_by: key={{ inventory_hostname in spark_set      and "SP" or "x" }}
       - group_by: key={{ inventory_hostname in uvcmetrics_set and "UM" or "x" }}

--- a/playbooks/gobig/restart.yml
+++ b/playbooks/gobig/restart.yml
@@ -90,3 +90,9 @@
       - role: rabbitmq
         state: restarted
 
+  - hosts: RM
+    roles:
+      - role: romanesco
+        rabbitmq_ansible_group: RQ
+        state: restarted
+

--- a/playbooks/gobig/site.yml
+++ b/playbooks/gobig/site.yml
@@ -89,3 +89,9 @@
       - role: rabbitmq
         state: started
 
+  - hosts: RM
+    roles:
+      - role: romanesco
+        rabbitmq_ansible_group: RQ
+        state: started
+

--- a/playbooks/gobig/uninstall.yml
+++ b/playbooks/gobig/uninstall.yml
@@ -50,3 +50,9 @@
       - role: rabbitmq
         state: absent
 
+  - hosts: RM
+    roles:
+      - role: romanesco
+        rabbitmq_ansible_group: RQ
+        state: absent
+

--- a/playbooks/romanesco/site.yml
+++ b/playbooks/romanesco/site.yml
@@ -1,0 +1,8 @@
+---
+
+  - hosts: romanesco
+    roles:
+      - role: romanesco
+        rabbitmq_ansible_group: rabbitmq
+        state: started
+

--- a/playbooks/romanesco/uninstall.yml
+++ b/playbooks/romanesco/uninstall.yml
@@ -1,0 +1,8 @@
+---
+
+  - hosts: romanesco
+    roles:
+      - role: romanesco
+        rabbitmq_ansible_group: rabbitmq
+        state: absent
+

--- a/roles/romanesco-install/meta/main.yml
+++ b/roles/romanesco-install/meta/main.yml
@@ -1,0 +1,12 @@
+---
+
+dependencies:
+  - role: romanesco-variables
+  - role: user-generate
+    name: "{{ romanesco_user }}"
+    group: "{{ romanesco_group }}"
+    crypt_pass: "{{ romanesco_crypt_pass }}"
+    system: true
+    state: present
+    when: do_install|bool
+

--- a/roles/romanesco-install/tasks/main.yml
+++ b/roles/romanesco-install/tasks/main.yml
@@ -27,7 +27,6 @@
       - libtool
       - m4
       - make
-      - mongodb
       - ncurses-dev
       - openjdk-7-jdk
       - openjdk-7-jre-headless

--- a/roles/romanesco-install/tasks/main.yml
+++ b/roles/romanesco-install/tasks/main.yml
@@ -1,0 +1,122 @@
+---
+
+  - name: apt | cache | update
+    apt: update_cache=yes
+    when: do_install|bool
+
+  - name: romanesco | deps | install
+    apt: name={{ item }} state=present update_cache=yes
+    with_items:
+      - apt-utils
+      - autoconf
+      - build-essential
+      - curl
+      - cmake
+      - g++
+      - gfortran
+      - git
+      - gzip
+      - libbz2-dev
+      - libcppunit-dev
+      - libexpat-dev
+      - libffi-dev
+      - libjpeg-dev
+      - libpng-dev
+      - libsqlite-dev
+      - libssl-dev
+      - libtool
+      - m4
+      - make
+      - mongodb
+      - ncurses-dev
+      - openjdk-7-jdk
+      - openjdk-7-jre-headless
+      - openssh-client
+      - openssh-server
+      - python-pip
+      - python-software-properties
+      - python2.7-dev
+      - rsync
+      - sudo
+      - tar
+      - wget
+    when: do_install|bool
+
+  - name: romanesco | service | stop
+    service:
+        name: romanesco
+        state: stopped
+    ignore_errors: true
+    when: stop_services|bool
+
+  - name: romanesco | install root | delete
+    file:
+        path: "{{ romanesco_install_root }}"
+        state: absent
+    when: remove_install_root|bool
+
+  - name: romanesco | data root | delete
+    file:
+        path: "{{ romanesco_data_root }}"
+        state: absent
+    when: remove_data_root|bool
+
+  - name: romanesco | install parent | create
+    file:
+        path: "{{ romanesco_install_parent }}"
+        state: directory
+    when: do_install|bool
+
+  - name: romanesco | data root | create
+    file:
+        path: "{{ romanesco_data_root }}"
+        state: directory
+        mode: 0755
+    when: do_install|bool
+
+  - name: romanesco | data root | owner | set
+    file:
+        path: "{{ romanesco_data_root }}"
+        state: directory
+        group: "{{ romanesco_group }}"
+        owner: "{{ romanesco_user }}"
+        mode: 0775
+    when: do_install|bool
+
+  - name: romanesco | repo | sync
+    command: >
+        rsync -avz --exclude=.git
+        "{{ romanesco_git_work_dir }}/"
+        "{{ romanesco_install_root }}"
+    when: do_install|bool
+
+  - name: pip
+    pip: requirements={{ romanesco_install_root }}/{{ item }}
+    with_items:
+      - requirements.txt
+      - romanesco/plugins/girder_io/requirements.txt
+    when: do_install|bool
+
+  - name: romanesco | script | service | generate
+    template:
+        src: run-service.j2
+        dest: "{{ romanesco_install_root }}/run-service"
+        mode: 0755
+    when: do_install|bool
+
+  - name: romanesco | conf | owner | set
+    file:
+        recurse: yes
+        path: "{{ romanesco_install_root }}"
+        group: "{{ romanesco_group }}"
+        mode: 0755
+        owner: "{{ romanesco_user }}"
+    when: do_install|bool
+
+  - name: romanesco | conf | set
+    template:
+        src: worker.local.cfg.j2
+        dest: "{{ romanesco_install_root }}/romanesco/worker.local.cfg"
+        mode: 0644
+    when: do_install|bool
+

--- a/roles/romanesco-install/templates/run-service.j2
+++ b/roles/romanesco-install/templates/run-service.j2
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+
+# f="$( ls /opt/uvcdat/*/bin/setup_runtime.sh 2>/dev/null | tail -n 1 )"
+# if [ -n "$f" ] ; then source "$f" ; fi
+
+f="$( ls /opt/spark/*/conf/spark-env.sh 2>/dev/null | tail -n 1 )"
+if [ -n "$f" ] ; then source "$f" ; fi
+
+f="$( dirname "$( dirname "$f" )" )"
+export PYTHONPATH="$f/python:$f/python/lib/py4j-0.8.2.1-src.zip:$PYTHONPATH"
+
+cd {{ romanesco_install_root }}
+python -m romanesco
+

--- a/roles/romanesco-install/templates/worker.local.cfg.j2
+++ b/roles/romanesco-install/templates/worker.local.cfg.j2
@@ -1,0 +1,10 @@
+
+[celery]
+app_main={{ romanesco_main_app_name }}
+broker={{ romanesco_celery_broker }}
+
+[romanesco]
+tmp_root={{ romanesco_tmp_root }}
+plugins_enabled=girder_io,spark
+plugin_load_path={{ romanesco_plugin_load_path | join(":") }}
+

--- a/roles/romanesco-service-install/meta/main.yml
+++ b/roles/romanesco-service-install/meta/main.yml
@@ -1,0 +1,12 @@
+---
+
+dependencies:
+  - role: romanesco-variables
+  - role: upstart
+    name: romanesco
+    user: "{{ romanesco_user }}"
+    group: "{{ romanesco_group }}"
+    description: Romanesco Execution Engine Service
+    command: "{{ romanesco_install_root }}/run-service"
+    when: do_install|bool
+

--- a/roles/romanesco-service/meta/main.yml
+++ b/roles/romanesco-service/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+  - role: romanesco-variables
+

--- a/roles/romanesco-service/tasks/main.yml
+++ b/roles/romanesco-service/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+  - name: romanesco | service
+    service:
+        name: romanesco
+        state: "{{ state }}"
+    when: notify_services|bool
+

--- a/roles/romanesco-variables/defaults/main.yml
+++ b/roles/romanesco-variables/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+
+    romanesco_version: master
+    romanesco_install_root: ""
+    romanesco_data_root: ""
+
+    romanesco_user: romanesco
+    romanesco_group: romanesco
+    romanesco_crypt_pass: ""
+    romanesco_net_interface: eth0
+
+    romanesco_main_app_name: romanesco
+    romanesco_celery_broker: ""
+    romanesco_tmp_root: ""
+    romanesco_plugin_load_path: []
+
+    state: started
+

--- a/roles/romanesco-variables/meta/main.yml
+++ b/roles/romanesco-variables/meta/main.yml
@@ -1,0 +1,10 @@
+---
+
+dependencies:
+  - role: git-cache
+    repo: git://github.com/kitware/romanesco.git
+    version: "{{ romanesco_version }}"
+    variable_prefix: romanesco
+    state: present
+  - role: nodejs-variables
+

--- a/roles/romanesco-variables/tasks/main.yml
+++ b/roles/romanesco-variables/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+
+  - name: romanesco | service | logic flags | compute
+    set_fact:
+        remove_data_root: "{{ state == 'absent' }}"
+        remove_install_root: "{{ state == 'absent' }}"
+        stop_services: "{{ state == 'absent' }}"
+        do_install: >
+            {{ state == "present" or state == "stopped" or
+               state == "started" or state == "restarted" or
+               state == "reloaded" }}
+        notify_services: >
+            {{ state == "stopped" or state == "started" or
+               state == "restarted" or state == "reloaded" }}
+
+  - name: romanesco | install root | default | set
+    set_fact:
+        romanesco_install_root: /opt/romanesco/{{ romanesco_git_version }}
+    when: romanesco_install_root == ""
+
+  - name: romanesco | install root | parent | probe
+    shell: dirname "{{ romanesco_install_root }}"
+    register: parent_probe
+
+  - name: romanesco | install root | parent | record
+    set_fact:
+        romanesco_install_parent: "{{ parent_probe.stdout }}"
+
+  - name: romanesco | data root | default | set
+    set_fact:
+        romanesco_data_root: /data/romanesco/{{ romanesco_git_version }}
+    when: romanesco_data_root == ""
+
+  - name: romanesco | tmp root | default | set
+    set_fact:
+        romanesco_tmp_root: "{{ romanesco_data_root }}/tmp"
+    when: romanesco_tmp_root == ""
+
+  - name: romanesco | celery broker | default | set
+    set_fact:
+        romanesco_celery_broker: >
+            amqp://{{ hostvars[groups[rabbitmq_ansible_group][0]]
+                              ["ansible_" + romanesco_net_interface]
+                              ["ipv4"]
+                              ["address"] }}
+    when: romanesco_celery_broker == ""
+
+  - name: romanesco | install root | probe
+    stat:
+        path: "{{ romanesco_install_root }}"
+    register: install_root_probe
+
+  - name: romanesco | install root | flag | record
+    set_fact:
+        create_install_root: >
+            {{ (do_install|bool) and
+                (not (install_root_probe.stat.exists|bool)) }}
+
+  - name: romanesco | initialized | probe
+    stat:
+        path: "{{ romanesco_data_root }}/.initialized"
+    register: initialized_probe
+
+  - name: romanesco | initialized | flag | record
+    set_fact:
+        do_initialization: >
+            {{ (do_install|bool) and
+                (not (initialized_probe.stat.exists|bool)) }}
+

--- a/roles/romanesco/meta/main.yml
+++ b/roles/romanesco/meta/main.yml
@@ -1,0 +1,8 @@
+---
+
+dependencies:
+  - role: romanesco-variables
+  - role: romanesco-install
+  - role: romanesco-service-install
+  - role: romanesco-service
+


### PR DESCRIPTION
Seventh among a series of PR's.

Adds a new role: `romanesco`, for provisioning and managing romanesco nodes.

Initially contains the commits from all prior PR's in the series (will be rebased after they are merged).

New commits: 1
