### PR TITLE
EC2-pod role

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Collection of Ansible roles useful for provisioning a variety of services over
 clusters for HPC and data-intensive applications.
 
 ### Roles
+  - [ec2-pod](doc/ec2-pod.md)
   - [girder](doc/girder.md)
   - [hdfs-namenode](doc/hadoop.md)
   - [hdfs-datanode](doc/hadoop.md)

--- a/doc/ec2-pod.md
+++ b/doc/ec2-pod.md
@@ -1,0 +1,166 @@
+
+### ec2-pod
+manages a self-contained collection of AWS EC2 instances
+
+The `ec2-pod` role can be used to manage a "pod", or a self-contained collection
+of AWS EC2 instances organized under a single security group.  The instances and
+their properties are specified as part of the YAML document where the role is
+used.  The role also dynamically adds managed instances to the current
+inventory, allowing the instances to be provisioned after management in one
+single playbook.  Combined with the aformentioned instance specification, the
+`ec2-pod` role may be used to add to- or in lieu of- a play's initial
+inventory.
+
+#### Variables
+
+|Name                 |Default       |Description                                       |
+|:--------------------|:------------:|:-------------------------------------------------|
+|default_image        |ami-d05e75b8  |default ami image to use for instances            |
+|default_instance_type|t2.medium     |default instance type                             |
+|default_ssh_key      |ec2           |name of the default keypair to use                |
+|hosts                |(empty)       |hosts specification                               |
+|name                 |pod           |name of the pod to manage                         |
+|region               |us-east-1     |region to use for the pod's instances             |
+|rules                |(all open)    |firewall rules for the pod's security group       |
+|rules_egress         |(all open)    |firewall egress rules for the pod's security group|
+|state                |running       |state of the pod's instances                      |
+
+#### Notes
+
+  - Proper operation of this role requires that the `AWS_ACCESS_KEY_ID` and
+    `AWS_SECRET_ACCESS_KEY` environment variables be set to the credentials
+    necessary to access the desired AWS account.
+
+  - The `default_image`, `default_instance_type`, and `default_ssh_key`
+    variables provide defaults for the instances' image, type, and key,
+    respectively.
+
+  - Details on the format of the `hosts` specification variable is provided
+    under [Hosts Specification](#hosts-specification).
+
+  - The format of the `rules` and `rules_egress` variables follow the same
+    format as that documented in the Ansible
+    [ec2_group](http://docs.ansible.com/ansible/ec2_group_module.html) module.
+
+  - `state` can be "absent", "stopped", or "running".
+
+  - As a special case, setting `state` to "absent" will terminate every instance
+    that had once been part of a pod by the same name (given in `pod`),
+    even if such instances have no matching entry in the `hosts` specification.
+
+##### Hosts Specification
+
+The `hosts` specification variable is a key-value mapping of instance names to
+instance options.
+
+|Name   |Default                |Description                                   |
+|:------|:---------------------:|:---------------------------------------------|
+|count  |1                      |number of instances to manage                 |
+|groups |(empty)                |list of ansible groups to add this instance to|
+|image  |(default image)        |ami image to use for this instance            |
+|name   |(generated)            |name of the instance                          |
+|ssh_key|(default ssh key)      |name of the keypair to use for this instance  |
+|type   |(default instance type)|type of this instance                         |
+|volumes|(empty)                |volumes specification                         |
+
+##### Notes
+
+  - In addition to any given `groups`, all managed instances are added to a
+    catch-all ansible group with the same name as the pod.
+
+  - By default, the name of the instance is a mangled name that includes the
+    name of the pod followed by the key matching this entry in the `hosts`
+    specification.  Set the `name` variable to override this generated name.
+
+  - The optional `volumes` specification variable for a given hosts
+    specification entry is a key-value mapping of volume device names to volume
+    capacities (in GiB).  Volumes should be specified with names as in "sdb",
+    "sdc", and so on (modification of the instance's root volume, "sda" is not
+    supported).  Note that the volumes are mounted within the instances under
+    mount points such as "xvdb", "xvdc", etc.
+
+#### Examples
+
+Create a new ec2 pod called "gobig".  Ssh to the managed instances will be done
+using the "gobig" ssh key pair.  The pod's security group will allow inbound tcp
+traffic over the ssh port.  Outbound, the security group allows all traffic (the
+default).  The instances consist of a single `t2.medium` instance called
+"girder" with an additional 20 GiB volume available under `/dev/xvdb` -- and
+three `m3.large` instances called "spark", each with an additional 100 GiB
+volume available under `/dev/xvdb`.
+
+The `ec2-pod` role tries to be idempotent in all cases, so if, for example,
+there already exists a pod called "gobig" with two matching and running "girder"
+instances, and one matching and running "spark" instance, one of the spare
+"girder" instances would be terminated, and two new "spark" instances would be
+created.  As another example, if a preexisting matching pod had two "spark"
+instances, one of which was stopped, The running instance would be reused, the
+stopped instance restarted, and a new instance created.  In cases of excess
+instances, stopped instances are preferentially chosen for termination before
+terminating running instances, so for a pod with one running "girder" instance
+and one stopped "girder" instance, this example would terminate the stopped
+instance and leave the running instance as is.
+
+The instances can then be further provisioned within the same playbook by
+targetting the groups given under each instances' `hosts` specification, or by
+targetting the pod-wide group, "gobig".
+
+```YAML
+  - hosts: localhost
+    connection: local
+    gather_facts: false
+    become: false
+    roles:
+      - role: ec2-pod
+        default_ssh_key: gobig
+        name: gobig
+        rules:
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: 0.0.0.0/0
+
+        hosts:
+            girder:
+                name: girder
+                groups:
+                  - girder
+                  - resonant
+                type: t2.medium
+                volumes:
+                    sdb: 20
+            spark:
+                name: spark
+                count: 3
+                groups:
+                  - spark
+                type: m3.large
+                volumes:
+                    sdb: 100
+
+  - hosts: gobig
+    tasks:
+      - name: filesystems | create
+        filesystem:
+            fstype: ext4
+            dev: /dev/xvdb
+
+      - name: filesystems | mount
+        mount:
+            fstype: ext4
+            name: /data
+            src: /dev/xvdb
+            state: mounted
+
+      - etc...
+
+  - hosts: girder
+    etc...
+
+  - hosts: resonant
+    etc...
+
+  - hosts: spark
+    etc...
+```
+

--- a/filter_plugins/ec2.py
+++ b/filter_plugins/ec2.py
@@ -1,0 +1,120 @@
+
+def flatten_ec2_result(ec2_result):
+    result = []
+    for entry in ec2_result["results"]:
+        for instance in entry["tagged_instances"]:
+            result.append({"hostname": instance["public_dns_name"],
+                           "id": instance["id"],
+                           "groups": entry["item"]["value"]["groups"]})
+
+    return result
+
+def process_hosts_spec(hosts_spec, pod_name):
+    result = {}
+    for key, value in hosts_spec.items():
+        value["groups"] = list(set(value.get("groups", ())) |
+                               set((pod_name,)))
+
+        if "volumes" in value:
+            new_volumes = []
+            for volume_name, volume_size in value["volumes"].items():
+                new_volumes.append({"delete_on_termination": True,
+                                    "device_name": "/dev/" + volume_name,
+                                    "volume_size": volume_size})
+
+            value["volumes"] = new_volumes
+
+        result[key] = value
+
+    return result
+
+def compute_ec2_update_lists(pod_name,
+                             hosts_spec,
+                             state,
+                             region,
+                             default_ssh_key,
+                             default_image,
+                             default_instance_type):
+
+    from collections import defaultdict
+    from itertools import chain
+    from boto import ec2
+
+    conn = ec2.connect_to_region(region)
+    if conn is None:
+        raise Exception(" ".join((
+            "region name:",
+            region,
+            "likely not supported, or AWS is down."
+            "connection to region failed.")))
+
+    reservations = conn.get_all_instances()
+
+    # short-circuit the case where the pod should be terminated
+    if state == "absent":
+        return {"start": [], "terminate": list(set(
+            chain.from_iterable(
+                (instance.id for instance in reservation.instances
+                 if instance.tags.get("ec2_pod") == pod_name)
+                for reservation in reservations)
+        ))}
+
+    ec2_host_table = defaultdict(lambda: defaultdict(set))
+    for reservation in reservations:
+        for instance in reservation.instances:
+            if instance.tags.get("ec2_pod") != pod_name:
+                continue
+
+            if instance.state not in ("running", "stopped"):
+                continue
+
+            instance_name = instance.tags.get("ec2_pod_instance_name")
+            composite_key = (unicode(instance_name),
+                             unicode(instance.key_name),
+                             unicode(instance.image_id),
+                             unicode(instance.instance_type))
+
+            ec2_host_table[composite_key][instance.state].add(instance.id)
+
+    host_counter_table = dict(
+        ((unicode(key),
+          unicode(value.get("ssh_key", default_ssh_key)),
+          unicode(value.get("image", default_image)),
+          unicode(value.get("type", default_instance_type))),
+         value.get("count", 1))
+        for key, value in hosts_spec.items())
+
+    start_set = set()
+    terminate_set = set()
+
+    for composite_key, sets in ec2_host_table.items():
+        running_list = list(sets["running"])
+        stopped_list = list(sets["stopped"])
+
+        num_running = len(running_list)
+        num_stopped = len(stopped_list)
+
+        num_wanted = host_counter_table.get(composite_key, 0)
+
+        num_to_keep = min(num_running, num_wanted)
+        num_to_start = num_wanted - num_to_keep
+
+        start_set |= set(stopped_list[:num_to_start])
+
+        terminate_set |= set(stopped_list[num_to_start:])
+        terminate_set |= set(running_list[num_to_keep:])
+
+    import pprint
+    return {"start": list(start_set), "terminate": list(terminate_set)}
+
+def get_ec2_hosts(instance_table):
+    import operator as op
+    return map(op.itemgetter("id"), instance_table)
+
+class FilterModule(object):
+    def filters(self):
+        return {"compute_ec2_update_lists": compute_ec2_update_lists,
+                "flatten_ec2_result": flatten_ec2_result,
+                "get_ec2_hosts": get_ec2_hosts,
+                "process_hosts_spec": process_hosts_spec}
+

--- a/playbooks/gobig/ec2/instantiate.yml
+++ b/playbooks/gobig/ec2/instantiate.yml
@@ -1,0 +1,35 @@
+---
+
+  - hosts: localhost
+    connection: local
+    gather_facts: false
+    become: false
+    pre_tasks:
+      - include: pod_config.yml
+    roles:
+      - role: ec2-pod
+        default_ssh_key: "{{ ec2_pod_spec.key }}"
+        name: gobig
+        state: running
+        rules: "{{ ec2_pod_spec.rules }}"
+        hosts: "{{ ec2_pod_spec.hosts }}"
+
+  - hosts: gobig
+    tasks:
+      - name: filesystems | create
+        filesystem:
+            fstype: ext4
+            dev: /dev/{{ item }}
+        with_items:
+          - xvdb
+          - xvdc
+      - name: filesystems | mount
+        mount:
+            fstype: ext4
+            name: "{{ item.value }}"
+            src: /dev/{{ item.key }}
+            state: mounted
+        with_dict:
+            xvdb: /opt
+            xvdc: /data
+

--- a/playbooks/gobig/ec2/pod_config.yml
+++ b/playbooks/gobig/ec2/pod_config.yml
@@ -1,0 +1,132 @@
+---
+
+  - name: set ec2 pod specification
+    set_fact:
+        ec2_pod_spec:
+            key: gobig
+            rules:
+              - proto: icmp # ping
+                from_port: -1
+                to_port: -1
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # ssh
+                from_port: 22
+                to_port: 22
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # mongodb
+                from_port: 27017
+                to_port: 27017
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # mongodb
+                from_port: 28017
+                to_port: 28017
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # hdfs namenode
+                from_port: 8020
+                to_port: 8020
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # hdfs datanode
+                from_port: 3888
+                to_port: 3888
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # hdfs namenode webui
+                from_port: 50010
+                to_port: 50010
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # hdfs datanode webui
+                from_port: 50020
+                to_port: 50020
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # webhdfs
+                from_port: 50080
+                to_port: 50080
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # zookeeper
+                from_port: 2181
+                to_port: 2181
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # mesos master
+                from_port: 5050
+                to_port: 5050
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # mesos slave
+                from_port: 5051
+                to_port: 5051
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp # spark dispatcher
+                from_port: 7077
+                to_port: 7077
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp
+                from_port: 9080 # girder http
+                to_port: 9080
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp
+                from_port: 50081 # ???
+                to_port: 50081
+                cidr_ip: 0.0.0.0/0
+
+              - proto: tcp
+                from_port: 8081 # ???
+                to_port: 8081
+                cidr_ip: 0.0.0.0/0
+
+            hosts:
+                0:
+                    type: m4.xlarge
+                    groups:
+                      - datanodes
+                      - zookeepers
+                      - masters
+                      - slaves
+                      - spark
+                      - uvcmetrics
+                      - namenodes
+                      - rabbitmq
+                      - romanesco
+                    volumes:
+                        sdb: 50
+                        sdc: 50
+
+                1:
+                    type: m4.xlarge
+                    groups:
+                      - datanodes
+                      - zookeepers
+                      - masters
+                      - slaves
+                      - spark
+                      - uvcmetrics
+                      - mongodb
+                    volumes:
+                        sdb: 50
+                        sdc: 50
+
+                2:
+                    type: m4.xlarge
+                    groups:
+                      - datanodes
+                      - zookeepers
+                      - masters
+                      - slaves
+                      - spark
+                      - uvcmetrics
+                      - girder
+                    volumes:
+                        sdb: 50
+                        sdc: 50
+

--- a/playbooks/gobig/ec2/restart.yml
+++ b/playbooks/gobig/ec2/restart.yml
@@ -1,0 +1,5 @@
+---
+
+  - include: instantiate.yml
+  - include: ../restart.yml
+

--- a/playbooks/gobig/ec2/site.yml
+++ b/playbooks/gobig/ec2/site.yml
@@ -1,0 +1,5 @@
+---
+
+  - include: instantiate.yml
+  - include: ../site.yml
+

--- a/playbooks/gobig/ec2/stop.yml
+++ b/playbooks/gobig/ec2/stop.yml
@@ -1,0 +1,16 @@
+---
+
+  - hosts: localhost
+    connection: local
+    gather_facts: false
+    become: false
+    pre_tasks:
+      - include: pod_config.yml
+    roles:
+      - role: ec2-pod
+        default_ssh_key: "{{ ec2_pod_spec.key }}"
+        name: gobig
+        state: stopped
+        rules: "{{ ec2_pod_spec.rules }}"
+        hosts: "{{ ec2_pod_spec.hosts }}"
+

--- a/playbooks/gobig/ec2/terminate.yml
+++ b/playbooks/gobig/ec2/terminate.yml
@@ -1,0 +1,16 @@
+---
+
+  - hosts: localhost
+    connection: local
+    gather_facts: false
+    become: false
+    pre_tasks:
+      - include: pod_config.yml
+    roles:
+      - role: ec2-pod
+        default_ssh_key: "{{ ec2_pod_spec.key }}"
+        name: gobig
+        state: absent
+        rules: "{{ ec2_pod_spec.rules }}"
+        hosts: "{{ ec2_pod_spec.hosts }}"
+

--- a/playbooks/gobig/ec2/uninstall.yml
+++ b/playbooks/gobig/ec2/uninstall.yml
@@ -1,0 +1,5 @@
+---
+
+  - include: instantiate.yml
+  - include: ../uninstall.yml
+

--- a/roles/ec2-pod/defaults/main.yml
+++ b/roles/ec2-pod/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+
+    name: pod
+
+    region: us-east-1
+
+    default_public_key: ec2
+    default_image: ami-d05e75b8
+    default_instance_type: t2.medium
+
+    rules:
+        - proto: all
+          from_port: all
+          to_port: all
+          cidr_ip: 0.0.0.0/0
+
+    rules_egress:
+        - proto: all
+          from_port: all
+          to_port: all
+          cidr_ip: 0.0.0.0/0
+
+    hosts: {}
+
+    state: running
+

--- a/roles/ec2-pod/tasks/main.yml
+++ b/roles/ec2-pod/tasks/main.yml
@@ -1,0 +1,133 @@
+---
+
+  - name: variables | control | compute
+    set_fact:
+        do_add: >
+            {{ state == "running" }}
+        do_create: >
+            {{ state == "running" or state == "stopped" }}
+        do_destroy: >
+            {{ state == "absent" }}
+        do_wait: >
+            {{ state == "running" }}
+
+  - name: hosts spec | process
+    set_fact:
+        hosts_spec: "{{ hosts|process_hosts_spec(name) }}"
+
+  - name: instances | update lists | compute
+    set_fact:
+        update_lists: >
+            {{ name|compute_ec2_update_lists(hosts,
+                                             state,
+                                             region,
+                                             default_ssh_key,
+                                             default_image,
+                                             default_instance_type) }}
+
+  - name: instances | terminate set | compute
+    set_fact:
+        terminate_set: >
+            {{ (update_lists.terminate
+                if (update_lists.terminate|length > 0)
+                else [])|union(update_lists.start
+                               if ((do_destroy|bool) and
+                                   (update_lists.start|length) > 0)
+                               else []) }}
+
+  - name: security group | create
+    ec2_group:
+        name: ec2_pod_{{ name }}
+        description: >
+            security group for ec2 pod: {{ name }}
+        region: "{{ region }}"
+        rules: "{{ rules }}"
+        rules_egress: "{{ rules_egress }}"
+    when: do_create|bool
+
+  - name: instances | terminate set | terminate
+    ec2:
+        instance_ids: "{{ terminate_set }}"
+        region: "{{ region }}"
+        state: absent
+        wait: yes
+        wait_timeout: 120 # two minutes
+    ignore_errors: true
+    when: (terminate_set|length > 0)|bool
+
+  - name: instances | start set | start
+    ec2:
+        instance_ids: "{{ update_lists.start }}"
+        region: "{{ region }}"
+        state: running
+        wait: yes
+        wait_timeout: "{{ EC2_TIMEOUT }}"
+    when: ((do_create|bool) and (update_lists.start|length) > 0)|bool
+
+  - name: instances | create
+    ec2:
+        count_tag:
+            Name: >
+                {{ item.value.name|default(
+                    ["ec2_pod", name, item.key]|join("_")) }}
+            ec2_pod: "{{ name }}"
+            ec2_pod_instance_name: "{{ item.key }}"
+        exact_count: "{{ (item.value.count|default(1))|int }}"
+        group: ec2_pod_{{ name }}
+        image: "{{ item.value.image|default(default_image) }}"
+        instance_tags:
+            Name: >
+                {{ item.value.name|default(
+                    ["ec2_pod", name, item.key]|join("_")) }}
+            ec2_pod: "{{ name }}"
+            ec2_pod_instance_name: "{{ item.key }}"
+        instance_type: "{{ item.value.type|default(default_instance_type) }}"
+        key_name: "{{ item.value.ssh_key|default(default_ssh_key) }}"
+        region: "{{ region }}"
+        volumes: "{{ item.value.volumes|default([]) }}"
+        wait: yes
+        wait_timeout: "{{ EC2_TIMEOUT }}"
+    with_dict: "{{ hosts_spec }}"
+    when: do_create|bool
+    register: ec2_result
+
+  - name: instances | collection | flatten
+    set_fact:
+        instances: "{{ ec2_result|flatten_ec2_result }}"
+    when: do_create|bool
+
+  - name: instances | state | set
+    ec2:
+        instance_ids: "{{ instances|get_ec2_hosts }}"
+        region: "{{ region }}"
+        state: "{{ state }}"
+        wait: yes
+        wait_timeout: "{{ EC2_TIMEOUT }}"
+    when: do_create|bool
+
+  - name: instances | ansible groups | add
+    add_host:
+        hostname: "{{ item.hostname }}"
+        groups: >
+            {{ item.groups|join(",") }}
+    with_items: "{{ instances|default([None]) }}"
+    when: do_add|bool
+
+  - name: instances | ssh | wait
+    wait_for:
+        host: "{{ item.hostname }}"
+        port: 22
+        timeout: "{{ SSH_TIMEOUT }}"
+        state: started
+    with_items: "{{ instances|default([None]) }}"
+    when: do_wait|bool
+
+  - name: security group | destroy
+    ec2_group:
+        description: >
+            security group for ec2 pod: {{ name }}
+        region: "{{ region }}"
+        name: ec2_pod_{{ name }}
+        state: absent
+    when: do_destroy|bool
+

--- a/roles/ec2-pod/vars/main.yml
+++ b/roles/ec2-pod/vars/main.yml
@@ -1,0 +1,5 @@
+---
+
+    EC2_TIMEOUT: 1800 # 1/2 hour
+    SSH_TIMEOUT:  600 # 10 minutes
+


### PR DESCRIPTION
Ninth and final PR among a series of PR's.

Adds a new role: `ec2-pod`, for provisioning and managing groups of AWS ec2 instances.

Initially contains the commits from all prior PR's in the series (will be rebased after they are merged).

New commits: 1
