### PR TITLE
Add a mount option to the vagrant host config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,8 +57,20 @@ Vagrant.configure(2) do |config|
       node.vm.network "private_network", ip: "192.168.33.2#{i}", netmask: "255.255.255.0"
       node.vm.hostname = "#{name}.#{domain}"
       node.vm.provider "virtualbox" do |vb|
+
         vb.memory = params["memory"] || 2048
         vb.cpus = params["cups"] || 2
+
+        if params.has_key?("mount")
+          mount = params['mount']
+          if mount.kind_of?(Array)
+            mount.each do |mnt|
+              config.vm.synced_folder mnt['src'], mnt['dest'], create: true
+            end
+          else
+            config.vm.synced_folder mount['src'], mount['dest'], create: true
+          end
+        end
       end
 
       # Only provision after all nodes have been spun up.

--- a/dev/vagrant.dist.yml
+++ b/dev/vagrant.dist.yml
@@ -12,6 +12,20 @@ nodes:
   head:
     memory: 8192
     cpus: 2
+# Nodes may mount local directories  by using the 'mount'
+# keyword.  This required either src and dest properties
+# Like so:
+#    mount:
+#      src: /home/user/src/repo/
+#      dest: /home/vagrant/src/repo
+#
+# Or a list of src and dest properties:
+#    mount:
+#      - src: /home/user/src/repo/
+#        dest: /home/vagrant/src/repo
+#      - src: /home/user/src/repo2/
+#        dest: /home/vagrant/src/repo2
+#      ....
     roles:
       - namenodes
       - datanodes


### PR DESCRIPTION
Allows for mounting local directories inside vagrant boxes through the `vagrant.local.yml` config file
