### PR TITLE
add option "add_by_hostname" to ec2-pod role

### DIFF
--- a/doc/ec2-pod.md
+++ b/doc/ec2-pod.md
@@ -13,17 +13,18 @@ inventory.
 
 #### Variables
 
-|Name                 |Default       |Description                                       |
-|:--------------------|:------------:|:-------------------------------------------------|
-|default_image        |ami-d05e75b8  |default ami image to use for instances            |
-|default_instance_type|t2.medium     |default instance type                             |
-|default_ssh_key      |ec2           |name of the default keypair to use                |
-|hosts                |(empty)       |hosts specification                               |
-|name                 |pod           |name of the pod to manage                         |
-|region               |us-east-1     |region to use for the pod's instances             |
-|rules                |(all open)    |firewall rules for the pod's security group       |
-|rules_egress         |(all open)    |firewall egress rules for the pod's security group|
-|state                |running       |state of the pod's instances                      |
+|Name                 |Default       |Description                                         |
+|:--------------------|:------------:|:---------------------------------------------------|
+|add_by_hostname      |false         |add managed hosts by hostname instead of IP address |
+|default_image        |ami-d05e75b8  |default ami image to use for instances              |
+|default_instance_type|t2.medium     |default instance type                               |
+|default_ssh_key      |ec2           |name of the default keypair to use                  |
+|hosts                |(empty)       |hosts specification                                 |
+|name                 |pod           |name of the pod to manage                           |
+|region               |us-east-1     |region to use for the pod's instances               |
+|rules                |(all open)    |firewall rules for the pod's security group         |
+|rules_egress         |(all open)    |firewall egress rules for the pod's security group  |
+|state                |running       |state of the pod's instances                        |
 
 #### Notes
 

--- a/filter_plugins/ec2.py
+++ b/filter_plugins/ec2.py
@@ -4,6 +4,7 @@ def flatten_ec2_result(ec2_result):
     for entry in ec2_result["results"]:
         for instance in entry["tagged_instances"]:
             result.append({"hostname": instance["public_dns_name"],
+                           "ip": instance["public_ip"],
                            "id": instance["id"],
                            "groups": entry["item"]["value"]["groups"]})
 

--- a/roles/ec2-pod/defaults/main.yml
+++ b/roles/ec2-pod/defaults/main.yml
@@ -20,6 +20,8 @@
           to_port: all
           cidr_ip: 0.0.0.0/0
 
+    add_by_hostname: false
+
     hosts: {}
 
     state: running

--- a/roles/ec2-pod/tasks/main.yml
+++ b/roles/ec2-pod/tasks/main.yml
@@ -10,6 +10,9 @@
             {{ state == "absent" }}
         do_wait: >
             {{ state == "running" }}
+        host_key: >
+            {{ "hostname" if (add_by_hostname|bool) else "ip" }}
+
 
   - name: hosts spec | process
     set_fact:
@@ -107,7 +110,7 @@
 
   - name: instances | ansible groups | add
     add_host:
-        hostname: "{{ item.hostname }}"
+        hostname: "{{ item[host_key] }}"
         groups: >
             {{ item.groups|join(",") }}
     with_items: "{{ instances|default([None]) }}"


### PR DESCRIPTION
Fixes #39 

Adds a new option: `add_by_hostname` to the `ec2-pod` role that serves as an explicit opt-in option for preserving the current behavior whereby managed ec2 instances are added to the live inventory by their public fqdn.  This behavior causes problems when ansible creates sockets for each of these hosts using file names that are too long.  Therefore, this PR changes the default behavior to add the instances by their public ip addresses (far fewer characters needed).
