### PR TITLE
Add hadoop classpath vars to SPARK_DIST_CLASSPATH

### DIFF
--- a/roles/spark-install/templates/spark-env.sh.j2
+++ b/roles/spark-install/templates/spark-env.sh.j2
@@ -9,9 +9,8 @@ export SPARK_LOCAL_IP="{{ hostvars[inventory_hostname]
                                   ['ipv4']
                                   ['address'] }}"
 
-export SPARK_CLASSPATH="$( "$HADOOP_HOME/bin/hadoop" classpath )"
+export SPARK_DIST_CLASSPATH="$( "$HADOOP_HOME/bin/hadoop" classpath )"
 export MESOS_NATIVE_JAVA_LIBRARY="$MESOS_HOME/build/src/.libs/libmesos.so"
 
 export SPARK_LOG_DIR="$SPARK_HOME/logs"
 export SPARK_PID_DIR="{{ spark_data_root }}/pids"
-

--- a/roles/spark-standalone-install/templates/spark-env.sh.j2
+++ b/roles/spark-standalone-install/templates/spark-env.sh.j2
@@ -12,7 +12,7 @@ export SPARK_LOCAL_IP="{{ hostvars[inventory_hostname]
                                   ['address'] }}"
 
 {% if hadoop_profile == "without-hadoop" %}
-export SPARK_CLASSPATH="$( "$HADOOP_HOME/bin/hadoop" classpath )"
+export SPARK_DIST_CLASSPATH="$( "$HADOOP_HOME/bin/hadoop" classpath )"
 {% endif %}
 
 export SPARK_LOG_DIR="$SPARK_HOME/logs"


### PR DESCRIPTION
http://spark.apache.org/docs/latest/hadoop-provided.html recommends
adding hadoop classpath to SPARK_DIST_CLASSPATH rather than
SPARK_CLASSPATH which throws deprecation warnings. 
