### PR TITLE
Add abs path for vagrant config files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,9 +16,9 @@ Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
 
   if File.exists?("dev/vagrant.local.yml")
-    nc = YAML.load_file("dev/vagrant.local.yml")
+    nc = YAML.load_file(File.dirname(__FILE__) + "/dev/vagrant.local.yml")
   else
-    nc = YAML.load_file("dev/vagrant.dist.yml")
+    nc = YAML.load_file(File.dirname(__FILE__) + "/dev/vagrant.dist.yml")
   end
 
   # Ensure nodes and ansible config sections exist

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.box = "ubuntu/trusty64"
 
-  if File.exists?("dev/vagrant.local.yml")
+  if File.exists?(File.dirname(__FILE__) + "/dev/vagrant.local.yml")
     nc = YAML.load_file(File.dirname(__FILE__) + "/dev/vagrant.local.yml")
   else
     nc = YAML.load_file(File.dirname(__FILE__) + "/dev/vagrant.dist.yml")


### PR DESCRIPTION
Normally relative paths are fine in vagrant files because `vagrant up` is run from the same directory as the `Vagrantfile`  unfortunately the command `vagrant global-status --prune` may run the `Vagrantfile` from a different directory and then balk because it can't find `dev/vagrant.local.yml`
