### PR TITLE
EC2 pod rework

### DIFF
--- a/doc/aws-credentials.md
+++ b/doc/aws-credentials.md
@@ -1,0 +1,48 @@
+
+### aws-credentials
+Load a set of AWS credentials as Ansible facts
+
+The `aws-credentials` role sets facts that later roles and tasks can use to
+interract with Amazon's AWS service.  It supports aws profiles, environment
+variables, and setting credentials explicitly in a playbook.
+
+#### Variables
+
+|Name           |Default                 |Description                           |
+|:--------------|:----------------------:|:-------------------------------------|
+|access_key     |(see notes)             |access key ID                         |
+|path           |"$HOME/.aws/credentials"|file path to the aws credentials file |
+|profile        |"default"               |aws credentials profile               |
+|secret_key     |(see notes)             |secret key                            |
+|variable_prefix|""                      |prefix to use for the output variables|
+
+#### Notes
+
+  - If provided, the `access_key` given will be passed through as-is.
+    Otherwise, the `AWS_ACCESS_KEY_ID` environment variable is used.  If the
+    environment variable is not set, `access_key` is taken from the given
+    `profile` in the aws credentials file given by `path`.
+
+  - If provided, the `secret_key` given will be passed through as-is.
+    Otherwise, the `AWS_SECRET_ACCESS_KEY` environment variable is used.  If the
+    environment variable is not set, `secret_key` is taken from the given
+    `profile` in the aws credentials file given by `path`.
+
+  - If defined, an underscore (`_`) is appended to `variable_prefix`.  This role
+    sets the following variables after possibly adding the underscore:
+      - `{{ variable_prefix }}aws_access_key_id`: access key ID
+      - `{{ variable_prefix }}aws_secret_key`: secret key
+
+#### Examples
+
+Parse the default aws credentials file and return the credentials for the
+`gobig` profile.
+
+```YAML
+  - hosts: localhost
+    connection: local
+    roles:
+      - role: aws-credentials
+        profile: gobig
+```
+

--- a/doc/ec2-pod2.md
+++ b/doc/ec2-pod2.md
@@ -1,0 +1,366 @@
+
+### ec2-pod2
+manages a self-contained collection of AWS EC2 resources
+
+The `ec2-pod2` role can be used to manage a "pod", or a self-contained
+collection of AWS EC2 resources organized under a single logical namespace.
+These managed resources include EBS volumes, security groups, placement groups,
+and elastic IPs -- as well as the EC2 instances and the key pairs used to
+remotely access them.  Their specifications are given as part of the YAML
+document where the role is used.  The role also dynamically adds managed
+instances to the current inventory, allowing the instances to be provisioned
+after management in one single playbook.  Combined with the aformentioned
+resource specification, the `ec2-pod2` role may be used to add to- or in lieu
+of- a play's initial inventory.
+
+#### Variables
+
+|Name                 |Default       |Description                                                                   |
+|:--------------------|:------------:|:-----------------------------------------------------------------------------|
+|aws_access_key_id    |(required)    |the ID of the AWS access key                                                  |
+|aws_secret_key       |(required)    |the secret token for the AWS access key                                       |
+|instances            |{}            |specification of the pod's instances                                          |
+|name                 |default       |name of the pod to manage                                                     |
+|options              |(see notes)   |additional options controlling the overall behavior of this role              |
+|placement_groups     |{}            |specification of the pod's placement groups                                   |
+|security_groups      |{}            |specification of the pod's security groups                                    |
+|ssh_keys             |{}            |specification of the ssh key pairs used to remotely access the pod's instances|
+|state                |running       |state of the pod's resources                                                  |
+|templates            |{}            |specification templates for properties common across multiple resources       |
+
+#### Notes
+
+  - For seamless handling of aws credentials, including profile support, see the
+    [`aws-credentials`](aws-credentials.md) role.
+
+  - Details on the format of the `instances` specification variable is provided
+    under [Instance Specification](#instance-specification).
+
+  - For entries recognized in the `options` variable, see
+    [Overall Options](#overall-options).
+
+  - Details on the format of the `placement_groups` specification variable is
+    provided under
+    [Placement Group Specification](#placement-group-specification).
+
+  - Details on the format of the `security_groups` specification variable is
+    provided under
+    [Security Group Specification](#security-group-specification).
+
+  - Details on the format of the `ssh_keys` specification variable is
+    provided under
+    [Keypair Specification](#keypair-specification).
+
+  - `state` can be "absent", "stopped", or "running".
+
+  - As a special case, setting `state` to "absent" will terminate every instance
+    that had once been part of a pod by the same name (given in `pod`), even if
+    such instances have no matching entry in the `instances` specification.
+
+  - See [Templating](#templating) for details on `ec2-pod2`'s templating
+    features and how to to take advantage of them.
+
+##### Instance Specification
+
+The `instances` specification variable is a key-value mapping of instance names
+to instance options.
+
+**Note**: Take advantage of `ec2-pod2`'s templating features.  See
+          [Templating](#templating) for more details.
+
+|Name                 |Default   |Description                                                                     |
+|:--------------------|:--------:|:---------------------------------------------                                  |
+|ansible_groups       |[]        |ansible groups to add this instance to                                          |
+|count                |1         |number of instances to manage                                                   |
+|extends              |""        |template from which this instance derives                                       |
+|extra_ansible_groups |[]        |additional ansible groups to add this instance to                               |
+|extra_security_groups|[]        |additional security groups to add this instance to                              |
+|image                |(required)|ami image to use for this instance                                              |
+|ip                   |""        |IP address of the elastic ip to associate with this instance                    |
+|placement_group      |""        |placement group to assign this instance to                                      |
+|security_groups      |[]        |security groups to add this instance to                                         |
+|ssh_key              |""        |name of the keypair entry to use for this instance                              |
+|type                 |(required)|type of this instance                                                           |
+|volumes              |[]        |volumes specification                                                           |
+|wait                 |true      |whether to wait for this instance to become accessible over ssh before returning|
+
+###### Notes
+  - The ansible groups that each instance is added to is the union of its
+    `ansible_groups` and `extra_ansible_groups` values.  The
+    `extra_ansible_groups` variable is provided as a convenience for specifying
+    a base set of ansible groups via templating.
+
+  - The security groups that each instance is added to is the union of its
+    `security_groups` and `extra_security_groups` values.  The
+    `extra_security_groups` variable is provided as a convenience for specifying
+    a base set of security groups via templating.  All referenced security
+    groups must have matching entries in this pod's `security_groups`
+    specification.
+
+  - A valid instance specification cannot simultaneously provide a static
+    elastic `ip` and a `count` greater than one.
+
+  - The optional `volumes` specification variable for a given instance
+    specification is a list of volume sizes in GiB.  The block device nodes
+    assigned to each instance's volumes are: `/dev/xvdb` for the first,
+    `/dev/xvdc` for the second, and so on.  Modification of the instance's root
+    volume (`/dev/xvda`) prior to launch is not supported.
+
+  - Set `wait` to `false` where waiting for ssh access to an instance is
+    unnecessary or detrimental.  An example of such a scenario involves managing
+    an instance in a security group that blocks ssh.  Care must be taken when
+    adding such instances to ansible groups -- to avoid connection errors when
+    targetting those groups in subsequent plays.
+
+##### Placement Group Specification
+
+The `placement_groups` specification variable is a key-value mapping of
+placement group names to placement group options.
+
+**Note**: Take advantage of `ec2-pod2`'s templating features.  See
+          [Templating](#templating) for more details.
+
+|Name    |Default      |Description                                     |
+|:-------|:-----------:|:-----------------------------------------------|
+|extends |""           |template from which this placement group derives|
+|strategy|"cluster"    |strategy used for placing member instances      |
+
+###### Notes
+  - As of this writing, `strategy` is the only configurable option supported on
+    AWS for placement groups, and "cluster" the only supported value.  Placement
+    group specifications set to an empty object (`{}`) will automatically use
+    these defaults.
+
+##### Security Group Specification
+
+The `security_groups` specification variable is a key-value mapping of security
+group names to the list of rules that restrict traffic involving member
+instances.  Note that the syntax for specifying security group rules is an
+extension of that used for the `rules` and `rules_egress` settings in Ansible's
+[ec2_group](http://docs.ansible.com/ansible/ec2_group_module.html) module.  In
+general, there is a one-to-many mapping between rules in this specification and
+the actual rules created for the security group.  Below are the options
+available for each rule.
+
+**Note**: Take advantage of `ec2-pod2`'s templating features.  See
+          [Templating](#templating) for more details.
+
+|Name   |Default      |Description                                                                                                             |
+|:------|:-----------:|:-----------------------------------------------------------------------------------------------------------------------|
+|cidr_ip|""           |only allow traffic with peers whose ip address lie within the given block                                               |
+|extends|""           |template from which this rule derives                                                                                   |
+|flow   |"in"         |only allow traffic with the given orientation                                                                           |
+|groups |[]           |only allow traffic that peers with an instance whose security group membership includes any of the given security groups|
+|port   |(any port/NA)|only allow traffic via the given ports                                                                                  |
+|protos |"all"        |only allow traffic that follows the given protocols                                                                     |
+
+###### Notes
+  - Valid values for `flow` include "in", where only rules allowing inbound
+    traffic are created, "out", where only rules allowing outbound traffic are
+    created, and "sym", where both sets of rules are created.
+
+  - All referenced security groups in `groups` must refer to another
+    `security_groups` entry in this pod's specification.
+
+  - The `port` value can take on several forms.  If a scalar, rules are created
+    that restrict traffic to the given port.  If a list, each item in the list
+    is considered in turn.  If an item is a scalar, rules are created as in the
+    singular scalar case.  If an item in the list is, itself, another list, it
+    must have at least two scalar elements and rules are created that restrict
+    traffic to the range of ports between the first and second element,
+    inclusive.
+
+  - Valid values for `protos` include "tcp", "udp", "icmp", "all", and any other
+    values supported by Ansible's
+    [ec2_group](http://docs.ansible.com/ansible/ec2_group_module.html) module.
+
+##### Keypair Specification
+
+The `ssh_keys` specification variable is a key-value mapping of keypair names to
+the local file path<sup>1</sup> of the public key.  Instances using a given
+`ssh_key` entry will be accessible through ssh only with the matching private
+key.
+
+<sup>1</sup>The host or hosts to which the given path is local is determined by
+the connection specification for the play containing the current invocation of
+this role, which may not be `localhost`.  See Ansible's documentation on
+[delegation and local actions](http://docs.ansible.com/ansible/playbooks_delegation.html)
+for more information.
+
+##### Overall Options
+
+|Name                     |Default|Description                                                                   |
+|:------------------------|:-----:|:-----------------------------------------------------------------------------|
+|ansible_groups_amend     |true   |whether to add managed instances to groups with the current playbook inventory|
+|ansible_groups_amend_mode|"ip"   |format in which the instances' addresses are to be added                      |
+
+###### Notes
+
+  - Valid values for `ansible_groups_amend_mode` include "ip" and "hostname".
+
+
+##### Templating
+
+The `ec2-pod2` role provides templating features through the `templates` option
+in the pod configuration.  Using templates is an effective and flexible way to
+detail a pod's specification while cutting down on redundant boilerplate.  Via
+templates, configuration options common across multiple entries of a given
+resource can be specified in one place, and then reused or extended where
+particular resources differ.  The entries for the `templates` option mirror the
+prominent features of the rest of the pod configuration.
+
+|Name            |Description              |
+|:---------------|:------------------------|
+|instances       |instance templates       |
+|placement_groups|placement group templates|
+|rules           |rule templates           |
+
+Each entry of a particular class of template is a key-value mapping from the
+template name to the new default options provided by it.  Each template can
+provide options that feature in the configuration of the same resource class as
+that of the template.  For example, an instance template can specify values for
+`image` and `type` (as well as all the other instance options).  Instances that
+inherit from such a template need not specify their `image` or `type`, but
+inherit them from the template.  In this manner, templates can be used to
+provide configurable defaults.
+
+```YAML
+  - hosts: localhost
+    roles:
+      - role: ec2-pod2
+        name: my-pod
+        state: running
+
+        templates:
+            instances:
+                common: { "image": "ami-fce3c696", "type": "t2.medium" }
+
+        instances:
+            web-medium: { "extends": "common" }
+            web-large: { "extends": "common", "type": "t2.large" }
+```
+
+#### Examples
+
+Create a new ec2 pod called "gobig".  Ssh to the managed instances will be done
+using the "gobig" ssh key pair.  The pod's security group will allow inbound tcp
+traffic over the ssh port.  Outbound, the security group allows all traffic.
+The instances consist of a single `t2.medium` instance called "girder" with an
+additional 20 GiB volume available under `/dev/xvdb` -- and
+three `m3.large` instances called "spark", each with an additional 100 GiB
+volume available under `/dev/xvdb`.
+
+The `ec2-pod2` role tries to be idempotent in all cases, so if, for example,
+there already exists a pod called "gobig" with two matching and running "girder"
+instances, and one matching and running "spark" instance, one of the spare
+"girder" instances would be terminated, and two new "spark" instances would be
+created.  As another example, if a preexisting matching pod had two "spark"
+instances, one of which was stopped, The running instance would be reused, the
+stopped instance restarted, and a new instance created.  In cases of excess
+instances, stopped instances are preferentially chosen for termination before
+terminating running instances, so for a pod with one running "girder" instance
+and one stopped "girder" instance, this example would terminate the stopped
+instance and leave the running instance as is.
+
+The instances can then be further provisioned within the same playbook by
+targetting the groups given under each instances' `ansible_hosts` specification,
+or by targetting the common group, "gobig".
+
+```YAML
+  - hosts: localhost
+    connection: local
+    gather_facts: false
+    become: false
+    roles:
+      - role: ec2-pod2
+        name: gobig
+
+        ssh_keys:
+            main: "~/.ssh/id_rsa.pub"
+
+        security_groups:
+            main:
+              - { "flow": "in" , "proto": "tcp", "port": 22 }
+              - { "flow": "out", "proto": "all" }
+
+        instances:
+            girder:
+                ssh_key: main
+                ansible_groups: ["girder", "gobig"]
+                security_groups: ["main"]
+                type: t2.medium
+                image: ami-xyz
+                volumes: [20]
+            spark:
+                count: 3
+                ssh_key: main
+                ansible_groups: ["spark", "gobig"]
+                security_groups: ["main"]
+                type: m3.large
+                image: ami-xyz
+                volumes: [100]
+
+  - hosts: gobig
+    tasks:
+      - name: filesystems | create
+        filesystem:
+            fstype: ext4
+            dev: /dev/xvdb
+
+      - name: filesystems | mount
+        mount:
+            fstype: ext4
+            name: /data
+            src: /dev/xvdb
+            state: mounted
+
+      - etc...
+
+  - hosts: girder
+    etc...
+
+  - hosts: spark
+    etc...
+```
+
+Same as above, but using instance templates.
+
+```YAML
+  - hosts: localhost
+    connection: local
+    gather_facts: false
+    become: false
+    roles:
+      - role: ec2-pod2
+        name: gobig
+
+        ssh_keys:
+            main: "~/.ssh/id_rsa.pub"
+
+        security_groups:
+            main:
+              - { "flow": "in" , "proto": "tcp", "port": 22 }
+              - { "flow": "out", "proto": "all" }
+
+        instances:
+            girder:
+                extends: common-instance
+                extra_ansible_groups: ["girder"]
+            spark:
+                extends: common-instance
+                count: 3
+                extra_ansible_groups: ["spark"]
+                type: m3.large
+                volumes: [100]
+
+        templates:
+            instances:
+                common-instance:
+                    ssh_key: main
+                    ansible_groups: ["gobig"]
+                    security_groups: ["main"]
+                    type: t2.medium
+                    image: ami-xyz
+                    volumes: [20]
+```
+

--- a/filter_plugins/aws.py
+++ b/filter_plugins/aws.py
@@ -1,0 +1,34 @@
+
+def process_aws_credentials(config_path, profile, key_id, key):
+    """parses the given AWS credentials file and returns the referenced set of
+    AWS credentials.
+
+    The return value is a dictionary with the keys ``key_id`` and ``key``
+    containing the access key id and the secret access key, respectively.
+    If either ``key_id` or ``key`` are provided, the provided credentials are
+    returned without parsing any files.
+
+    :param config_path: path to credentials file to parse
+    :param profile: AWS profile from which to extract credentials while parsing
+    :param key_id: AWS access key id to use (disables parsing)
+    :param key: AWS secret access key to use (disables parsing)
+
+    :returns: the AWS credentials from the given profile, or the directly passed
+              credentials
+    """
+
+    from os.path import expanduser
+    from ConfigParser import ConfigParser
+
+    if not (key_id or key):
+        parser = ConfigParser()
+        parser.read([expanduser(config_path)])
+        key_id = parser.get(profile, "aws_access_key_id")
+        key    = parser.get(profile, "aws_secret_access_key")
+
+    return { "key_id": key_id, "key": key }
+
+class FilterModule(object):
+    def filters(self):
+        return {"process_aws_credentials": process_aws_credentials,}
+

--- a/filter_plugins/ec2.py
+++ b/filter_plugins/ec2.py
@@ -6,7 +6,9 @@ def flatten_ec2_result(ec2_result):
             result.append({"hostname": instance["public_dns_name"],
                            "ip": instance["public_ip"],
                            "id": instance["id"],
-                           "groups": entry["item"]["value"]["groups"]})
+                           "eip": entry["item"]["value"]["ip"],
+                           "wait": entry["item"]["value"]["wait"],
+                           "groups": entry["item"]["value"]["ansible_groups"]})
 
     return result
 

--- a/filter_plugins/ec2.py
+++ b/filter_plugins/ec2.py
@@ -136,10 +136,17 @@ def get_ec2_hosts(instance_table):
     import operator as op
     return map(op.itemgetter("id"), instance_table)
 
+def get_ec2_eips(instance_table):
+    import operator as op
+    return map(
+        op.itemgetter("eip", "id"),
+        filter(op.itemgetter("eip"), instance_table))
+
 class FilterModule(object):
     def filters(self):
         return {"compute_ec2_update_lists": compute_ec2_update_lists,
                 "flatten_ec2_result": flatten_ec2_result,
                 "compute_ec2_ein_mapping": compute_ec2_ein_mapping,
-                "get_ec2_hosts": get_ec2_hosts}
+                "get_ec2_hosts": get_ec2_hosts,
+                "get_ec2_eips": get_ec2_eips}
 

--- a/filter_plugins/ec2.py
+++ b/filter_plugins/ec2.py
@@ -142,11 +142,18 @@ def get_ec2_eips(instance_table):
         op.itemgetter("eip", "id"),
         filter(op.itemgetter("eip"), instance_table))
 
+def get_ec2_wait_list(instance_table, host_key):
+    import operator as op
+    return map(
+        op.itemgetter(host_key),
+        filter(op.itemgetter("wait"), instance_table))
+
 class FilterModule(object):
     def filters(self):
         return {"compute_ec2_update_lists": compute_ec2_update_lists,
                 "flatten_ec2_result": flatten_ec2_result,
                 "compute_ec2_ein_mapping": compute_ec2_ein_mapping,
+                "get_ec2_wait_list": get_ec2_wait_list,
                 "get_ec2_hosts": get_ec2_hosts,
                 "get_ec2_eips": get_ec2_eips}
 

--- a/filter_plugins/ec2.py
+++ b/filter_plugins/ec2.py
@@ -10,25 +10,6 @@ def flatten_ec2_result(ec2_result):
 
     return result
 
-def process_hosts_spec(hosts_spec, pod_name):
-    result = {}
-    for key, value in hosts_spec.items():
-        value["groups"] = list(set(value.get("groups", ())) |
-                               set((pod_name,)))
-
-        if "volumes" in value:
-            new_volumes = []
-            for volume_name, volume_size in value["volumes"].items():
-                new_volumes.append({"delete_on_termination": True,
-                                    "device_name": "/dev/" + volume_name,
-                                    "volume_size": volume_size})
-
-            value["volumes"] = new_volumes
-
-        result[key] = value
-
-    return result
-
 def compute_ec2_update_lists(pod_name,
                              hosts_spec,
                              state,
@@ -116,6 +97,5 @@ class FilterModule(object):
     def filters(self):
         return {"compute_ec2_update_lists": compute_ec2_update_lists,
                 "flatten_ec2_result": flatten_ec2_result,
-                "get_ec2_hosts": get_ec2_hosts,
-                "process_hosts_spec": process_hosts_spec}
+                "get_ec2_hosts": get_ec2_hosts}
 

--- a/library/ec2_placement_group.py
+++ b/library/ec2_placement_group.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+
+import sys
+
+__arg_spec = None
+def get_arg_spec():
+    if __arg_spec is not None: return __arg_spec
+
+    strats = ["cluster"]
+    states = ["present", "absent"]
+
+    __ arg_spec = ec2_argument_spec()
+    arg_spec.update({
+        "name"    : { "required":      True, "type": "str"                    },
+        "strategy": { "default" : "cluster", "type": "str", "choices": strats },
+        "state"   : { "default" : "present", "type": "str", "choices": states },
+    })
+
+    return __arg_spec
+
+def main():
+    module = AnsibleModule(argument_spec=get_arg_spec())
+
+    try:
+        import boto.ec2
+    except ImportError:
+        module.fail_json(msg="module not found: boto.ec2")
+
+    name     = module.params.get("name")
+    strategy = module.params.get("strategy")
+    state    = module.params.get("state")
+
+    ec2 = ec2_connect(module)
+
+    group_exists = any(
+        group.name == name
+        for group in ec2.get_all_placement_groups(filters={"group-name": name})
+    )
+
+    msg = "nothing to do"
+    changed = False
+
+    if state == "present" and not group_exists:
+        ec2.create_placement_group(name)
+        msg = "placement group {} created".format(name)
+        changed = True
+
+    elif state == "absent" and group_exists:
+        ec2.delete_placement_group(name)
+        msg = "placement group {} removed".format(name)
+        changed = True
+
+    module.exit_json(msg=msg,
+                     name=name,
+                     strategy=strategy,
+                     changed=changed)
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+main()
+

--- a/library/ec2_pod_process.py
+++ b/library/ec2_pod_process.py
@@ -1,0 +1,284 @@
+#!/usr/bin/python
+
+from itertools import chain, product
+
+def reg_get(x, *items):
+    try:
+        for item in items:
+            if item not in x:
+                return None
+            x = x[item]
+        return x
+    except TypeError:
+        return None
+
+def detect_cycles(template_namespace):
+    result = False
+
+    for object in template_namespace.values():
+        iter_flag = False
+
+        tracer_a = reg_get(object, "extends")
+        if tracer_a is None: break
+
+        tracer_b = reg_get(reg_get(template_namespace, tracer_a), "extends")
+
+        result = (tracer_a == tracer_b)
+        while not result and tracer_b is not None:
+            if iter_flag:
+                tracer_a = reg_get(
+                    reg_get(template_namespace, tracer_a), "extends")
+
+            tracer_b = reg_get(reg_get(template_namespace, tracer_b), "extends")
+
+            iter_flag = not iter_flag
+            result = (tracer_a == tracer_b)
+
+        if result: break
+
+    return result
+
+def render_helper(target, ns, result=None):
+    if result is None: result = {}
+    if target is None: return result
+
+    render_helper(ns.get(target.get("extends")), ns, result)
+    result.update(target)
+
+    return result
+
+def render(target, ns):
+    result = render_helper(target, ns)
+    result.pop("extends", None)
+    return result
+
+def process_rule(pod_name, rule, egress=False):
+    base = {}
+    base.update(rule)
+
+    flow = base.pop("flow", "in")
+    skip_rule = (     flow != "sym"
+                 and (flow != "out" or not egress)
+                 and (flow != "in"  or     egress))
+
+    if skip_rule: return
+
+    ports = []
+    port = base.pop("port", None)
+    if port is not None:
+        try:
+            for port_entry in port:
+                try:              from_port, to_port = tuple(port_entry)
+                except TypeError: from_port, to_port = (port_entry, port_entry)
+                ports.append((from_port, to_port))
+        except TypeError:
+            ports.append((port, port))
+
+    if not ports:
+        ports.append(None)
+
+    groups = base.pop("group", None)
+    if isinstance(groups, basestring) or groups is None: groups = [groups]
+
+    protos = base.pop("proto", "all")
+    if isinstance(protos, basestring): protos = [protos]
+
+    for (port_entry, group, proto) in product(ports, groups, protos):
+        result = {}
+        result.update(base)
+
+        from_port, to_port = (
+            2*("all",) if proto == "all" else
+            2*(-1,) if proto == "icmp" else
+            (1, (1 << 16) - 1)
+        )
+
+        if port_entry is not None:
+            from_port, to_port = port_entry
+
+        result["from_port"] = from_port
+        result["to_port"] = to_port
+
+        if group is not None:
+            result["group_name"] = "_".join((pod_name, "sg", group))
+            result["group_desc"] =  "".join((
+                "ec2 pod security group: ", pod_name, "/", group))
+
+        if proto is not None:
+            result["proto"] = proto
+
+        yield result
+
+def process_instance(pod_name, instance_name, instance):
+    result = {}
+    result.update(instance)
+
+    volumes = result.pop("volumes", [])
+    if volumes:
+        volumes = [
+            {
+                "device_name": "/dev/xvd" + chr(ord("b") + index),
+                "volume_size": size,
+                "delete_on_termination": True
+            }
+            for index, size in enumerate(volumes)
+        ]
+
+    result["volumes"] = volumes
+
+    placement_group = result.pop("placement_group", None)
+    if placement_group is not None:
+        placement_group = "_".join((pod_name, "pg", placement_group))
+        result["placement_group"] = placement_group
+
+    security_groups = result.pop("security_groups", [])
+    extra_security_groups = result.pop("extra_security_groups", [])
+    security_groups = set(security_groups) | set(extra_security_groups)
+    if security_groups:
+        security_groups = [
+            "_".join((pod_name, "sg", security_group))
+            for security_group in security_groups
+        ]
+        result["group"] = security_groups
+
+    ansible_groups = result.pop("ansible_groups", [])
+    extra_ansible_groups = result.pop("extra_ansible_groups", [])
+    ansible_groups = set(ansible_groups) | set(extra_ansible_groups)
+    if ansible_groups:
+        result["ansible_groups"] = list(ansible_groups)
+
+    result["count"] = result.pop("count", 1)
+
+    result["count_tag"] = {
+        "Name": "_".join((pod_name, "in", instance_name)),
+        "ec2_pod": pod_name,
+        "ec2_pod_instance_name": instance_name
+    }
+
+    ssh_key = result.pop("ssh_key")
+    ssh_key = "_".join((pod_name, "key", ssh_key))
+    result["ssh_key"] = ssh_key
+
+    eip = result.pop("ip", None)
+    if eip is not None:
+        if result["count"] > 1:
+            raise ValueError(
+                "Cannot associate an elastic IP when count > 1")
+
+    result["ip"] = eip
+
+    result["wait"] = result.pop("wait", True)
+
+    return result
+
+def main():
+    states = ["present", "running", "stopped", "absent"]
+
+    arg_spec = {
+        "instances"       : { "type": "dict" },
+        "name"            : { "type": "str"  },
+        "options"         : { "type": "dict" },
+        "placement_groups": { "type": "dict" },
+        "security_groups" : { "type": "dict" },
+        "ssh_keys"        : { "type": "dict" },
+        "state"           : { "type": "str", "choices": states },
+        "region"          : { "type": "str"  },
+        "templates"       : { "type": "dict" },
+    }
+
+    module = AnsibleModule(argument_spec=arg_spec)
+    get = module.params.get
+    exit = module.exit_json
+    fail = module.fail_json
+
+    instances        = get("instances"       )
+    pod_name         = get("name"            )
+    options          = get("options"         )
+    placement_groups = get("placement_groups")
+    security_groups  = get("security_groups" )
+    ssh_keys         = get("ssh_keys"        )
+    state            = get("state"           )
+    region           = get("region"          )
+    templates        = get("templates"       )
+
+    ssh_keys = {
+        "_".join((pod_name, "key", key_name)): key_path
+        for key_name, key_path in ssh_keys.items()
+    }
+
+    instance_templates = reg_get(templates, "instances") or {}
+    if detect_cycles(instance_templates):
+        fail(msg="cycle detected among instance templates",
+             templates=instance_templates,
+             changed=False)
+        return
+
+    placment_group_templates = reg_get(templates, "placment_groups") or {}
+    if detect_cycles(placment_group_templates):
+        fail(msg="cycle detected among placement group templates",
+             templates=placment_group_templates,
+             changed=False)
+        return
+
+    rule_templates = reg_get(templates, "rules") or {}
+    if detect_cycles(rule_templates):
+        fail(msg="cycle detected among rule templates",
+             templates=rule_templates,
+             changed=False)
+        return
+
+    instances = {
+        "_".join((pod_name, "in", instance_name)):
+            process_instance(
+                pod_name,
+                instance_name,
+                render(instance, instance_templates))
+        for instance_name, instance in instances.items()
+    }
+
+    placment_groups = {
+        "_".join((pod_name, "pg", group_name)):
+            render(placment_group, placment_group_templates)
+        for group_name, placment_group in placement_groups.items()
+    }
+
+    security_groups = {
+        "_".join((pod_name, "sg", group_name)): {
+            "rules": list(chain.from_iterable(
+                process_rule(pod_name, rendered_rule, False)
+                for rendered_rule in rendered_rules
+            )),
+
+            "rules_egress": list(chain.from_iterable(
+                process_rule(pod_name, rendered_rule, True)
+                for rendered_rule in rendered_rules
+            )),
+
+            "description": "".join((
+                "ec2 pod security group: ", pod_name, "/", group_name))
+        }
+
+        for group_name, rendered_rules in (
+            (
+                name, tuple(render(rule, rule_templates)
+                            for rule in rules)
+            )
+            for name, rules in security_groups.items()
+        )
+    }
+
+    exit(msg="pod processed successfully",
+         instances=instances,
+         name=pod_name,
+         options=options,
+         placement_groups=placement_groups,
+         security_groups=security_groups,
+         region=region,
+         ssh_keys=ssh_keys,
+         state=state,
+         changed=True)
+
+from ansible.module_utils.basic import *
+
+main()
+

--- a/playbooks/gobig/ec2/instantiate.yml
+++ b/playbooks/gobig/ec2/instantiate.yml
@@ -7,12 +7,17 @@
     pre_tasks:
       - include: pod_config.yml
     roles:
-      - role: ec2-pod
-        default_ssh_key: "{{ ec2_pod_spec.key }}"
-        name: gobig
+      - role: aws-credentials
+        profile: "{{ pod_config.profile }}"
+
+      - role: ec2-pod2
+        name: "{{ pod_config.name }}"
+        ssh_keys: "{{ pod_config.ssh_keys }}"
+        placement_groups: "{{ pod_config.placement_groups }}"
+        instances: "{{ pod_config.instances }}"
+        security_groups: "{{ pod_config.security_groups }}"
+        templates: "{{ pod_config.templates }}"
         state: running
-        rules: "{{ ec2_pod_spec.rules }}"
-        hosts: "{{ ec2_pod_spec.hosts }}"
 
   - hosts: gobig
     tasks:
@@ -27,7 +32,7 @@
         mount:
             fstype: ext4
             name: "{{ item.value }}"
-            src: /dev/{{ item.key }}
+            src: "/dev/{{ item.key }}"
             state: mounted
         with_dict:
             xvdb: /opt

--- a/playbooks/gobig/ec2/pod_config.yml
+++ b/playbooks/gobig/ec2/pod_config.yml
@@ -2,131 +2,70 @@
 
   - name: set ec2 pod specification
     set_fact:
-        ec2_pod_spec:
-            key: gobig
-            rules:
-              - proto: icmp # ping
-                from_port: -1
-                to_port: -1
-                cidr_ip: 0.0.0.0/0
+        pod_config:
+            name: gobig
+            profile: gobig
+            ssh_keys: { main: "~/.ssh/gobig.pub" }
+            placement_groups: { main: {} }
+            instances:
+                worker:
+                    extends: common
+                    extra_ansible_groups: ["namenodes", "rabbitmq", "romanesco"]
 
-              - proto: tcp # ssh
-                from_port: 22
-                to_port: 22
-                cidr_ip: 0.0.0.0/0
+                db:
+                    extends: common
+                    extra_ansible_groups: ["mongodb"]
 
-              - proto: tcp # mongodb
-                from_port: 27017
-                to_port: 27017
-                cidr_ip: 0.0.0.0/0
+                web:
+                    extends: common
+                    security_groups: ["external"]
+                    extra_ansible_groups: ["girder"]
+            security_groups:
+                external:
+                  - { extends: "public", proto: "icmp" } # ping
+                  - { extends: "public", port: [
+                                22, # ssh
+                              9080  # girder http
+                    ] }
 
-              - proto: tcp # mongodb
-                from_port: 28017
-                to_port: 28017
-                cidr_ip: 0.0.0.0/0
+                internal:
+                  - { extends: "public", port: 22 } # public ssh
+                  - { extends: "private", proto: "icmp" } # ping
+                  - { extends: "private", port: [
+                      27017, 28017, # mongodb
+                              8020, # hdfs namenode
+                              3888, # hdfs datanode
+                             50010, # hdfs namenode webui
+                             50020, # hdfs datanode webui
+                             50080, # web hdfs
+                              2181, # zookeeper
+                              5050, # mesos master
+                              5051, # mesos slave
+                              7077, # spark dispatcher
+                             50081, # ???
+                              8081  # ???
+                    ] }
 
-              - proto: tcp # hdfs namenode
-                from_port: 8020
-                to_port: 8020
-                cidr_ip: 0.0.0.0/0
+            templates:
+                instances:
+                    common:
+                        ssh_key: main
+                        type: m4.xlarge
+                        image: ami-fce3c696
+                        volumes: [50, 50]
+                        placement_group: main
+                        security_groups: ["internal"]
+                        ansible_groups:
+                          - gobig
+                          - datanodes
+                          - zookeepers
+                          - masters
+                          - slaves
+                          - spark
+                          - uvcmetrics
+                rules:
+                    public:  { flow: "sym", proto: "tcp", cidr_ip: "0.0.0.0/0" }
+                    private: { flow: "sym", proto: "tcp", groups: ["internal",
+                                                                   "external"] }
 
-              - proto: tcp # hdfs datanode
-                from_port: 3888
-                to_port: 3888
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp # hdfs namenode webui
-                from_port: 50010
-                to_port: 50010
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp # hdfs datanode webui
-                from_port: 50020
-                to_port: 50020
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp # webhdfs
-                from_port: 50080
-                to_port: 50080
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp # zookeeper
-                from_port: 2181
-                to_port: 2181
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp # mesos master
-                from_port: 5050
-                to_port: 5050
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp # mesos slave
-                from_port: 5051
-                to_port: 5051
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp # spark dispatcher
-                from_port: 7077
-                to_port: 7077
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp
-                from_port: 9080 # girder http
-                to_port: 9080
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp
-                from_port: 50081 # ???
-                to_port: 50081
-                cidr_ip: 0.0.0.0/0
-
-              - proto: tcp
-                from_port: 8081 # ???
-                to_port: 8081
-                cidr_ip: 0.0.0.0/0
-
-            hosts:
-                0:
-                    type: m4.xlarge
-                    groups:
-                      - datanodes
-                      - zookeepers
-                      - masters
-                      - slaves
-                      - spark
-                      - uvcmetrics
-                      - namenodes
-                      - rabbitmq
-                      - romanesco
-                    volumes:
-                        sdb: 50
-                        sdc: 50
-
-                1:
-                    type: m4.xlarge
-                    groups:
-                      - datanodes
-                      - zookeepers
-                      - masters
-                      - slaves
-                      - spark
-                      - uvcmetrics
-                      - mongodb
-                    volumes:
-                        sdb: 50
-                        sdc: 50
-
-                2:
-                    type: m4.xlarge
-                    groups:
-                      - datanodes
-                      - zookeepers
-                      - masters
-                      - slaves
-                      - spark
-                      - uvcmetrics
-                      - girder
-                    volumes:
-                        sdb: 50
-                        sdc: 50
 

--- a/playbooks/gobig/ec2/stop.yml
+++ b/playbooks/gobig/ec2/stop.yml
@@ -7,10 +7,15 @@
     pre_tasks:
       - include: pod_config.yml
     roles:
-      - role: ec2-pod
-        default_ssh_key: "{{ ec2_pod_spec.key }}"
-        name: gobig
+      - role: aws-credentials
+        profile: "{{ pod_config.profile }}"
+
+      - role: ec2-pod2
+        name: "{{ pod_config.name }}"
+        ssh_keys: "{{ pod_config.ssh_keys }}"
+        placement_groups: "{{ pod_config.placement_groups }}"
+        instances: "{{ pod_config.instances }}"
+        security_groups: "{{ pod_config.security_groups }}"
+        templates: "{{ pod_config.templates }}"
         state: stopped
-        rules: "{{ ec2_pod_spec.rules }}"
-        hosts: "{{ ec2_pod_spec.hosts }}"
 

--- a/playbooks/gobig/ec2/terminate.yml
+++ b/playbooks/gobig/ec2/terminate.yml
@@ -7,10 +7,12 @@
     pre_tasks:
       - include: pod_config.yml
     roles:
-      - role: ec2-pod
-        default_ssh_key: "{{ ec2_pod_spec.key }}"
-        name: gobig
+      - role: aws-credentials
+        profile: "{{ pod_config.profile }}"
+
+      - role: ec2-pod2
+        name: "{{ pod_config.name }}"
+        security_groups: "{{ pod_config.security_groups }}"
+        templates: "{{ pod_config.templates }}"
         state: absent
-        rules: "{{ ec2_pod_spec.rules }}"
-        hosts: "{{ ec2_pod_spec.hosts }}"
 

--- a/roles/aws-credentials/defaults/main.yml
+++ b/roles/aws-credentials/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+
+    profile: default
+    path: >
+        {{ ansible_env.HOME }}/.aws/credentials
+    access_key: >
+        {{ ansible_env.AWS_ACCESS_KEY_ID | default("") }}
+    secret_key: >
+        {{ ansible_env.AWS_SECRET_ACCESS_KEY | default("") }}
+    variable_prefix: ""
+

--- a/roles/aws-credentials/tasks/main.yml
+++ b/roles/aws-credentials/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+
+  - name: variable prefix | set
+    set_fact:
+        prefix: >
+            {{ variable_prefix + "_" if variable_prefix else "" }}
+
+  - name: aws configuration | process
+    set_fact:
+        result: >
+            {{ path | process_aws_credentials(profile,
+                                              access_key,
+                                              secret_key) }}
+
+  - name: output variables | set
+    set_fact: >
+        {{ prefix }}aws_access_key_id="{{ result.key_id }}"
+        {{ prefix }}aws_secret_key="{{ result.key }}"
+

--- a/roles/aws-credentials/vars/main.yml
+++ b/roles/aws-credentials/vars/main.yml
@@ -1,0 +1,7 @@
+---
+
+    aws_access_key_id: >
+        {{ ansible_env.AWS_ACCESS_KEY_ID | default("") }}
+    aws_secret_access_key: >
+        {{ ansible_env.AWS_SECRET_ACCESS_KEY | default("") }}
+

--- a/roles/ec2-pod2/defaults/main.yml
+++ b/roles/ec2-pod2/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+    instances: {}
+    name: default
+    options:
+        ansible_groups_amend: true
+        ansible_groups_amend_mode: ip
+    placement_groups: {}
+    security_groups: {}
+    ssh_keys: {}
+    state: running
+    templates: {}
+

--- a/roles/ec2-pod2/tasks/main.yml
+++ b/roles/ec2-pod2/tasks/main.yml
@@ -1,0 +1,205 @@
+---
+
+  - name: variables | control | compute
+    set_fact:
+        do_create: >
+            {{ state == "running" or state == "stopped" }}
+        do_destroy: >
+            {{ state == "absent" }}
+        do_wait: >
+            {{ state == "running" }}
+
+  - name: variables | control | compute (2)
+    set_fact:
+        do_add: >
+            {{ (do_create|bool) and (options.ansible_groups_amend|bool) }}
+
+  - name: pod spec | process
+    ec2_pod_process:
+        instances: "{{ instances }}"
+        name: "{{ name }}"
+        options: "{{ options }}"
+        placement_groups: "{{ placement_groups }}"
+        security_groups: "{{ security_groups }}"
+        ssh_keys: "{{ ssh_keys }}"
+        state: "{{ state }}"
+        region: "{{ region }}"
+        templates: "{{ templates }}"
+    register: pod_spec
+
+  - name: instances | update lists | compute
+    set_fact:
+        update_lists: >
+            {{ pod_spec.name|compute_ec2_update_lists(pod_spec.instances,
+                                                      pod_spec.state,
+                                                      pod_spec.region,
+                                                      aws_access_key_id,
+                                                      aws_secret_key) }}
+
+  - name: instances | ssh keys | create
+    ec2_key:
+        name: "{{ item.key }}"
+        key_material: "{{ lookup('file', item.value) }}"
+        region: "{{ pod_spec.region }}"
+        state: present
+        wait: yes
+        wait_timeout: 300 # five minutes
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+    with_dict: "{{ pod_spec.ssh_keys }}"
+    when: do_create|bool
+
+  - name: instances | terminate set | compute
+    set_fact:
+        terminate_set: >
+            {{ (update_lists.terminate
+                if (update_lists.terminate|length > 0)
+                else [])|union(update_lists.start
+                               if ((do_destroy|bool) and
+                                   (update_lists.start|length) > 0)
+                               else []) }}
+
+  - name: security groups | create
+    ec2_group:
+        name: "{{ item.key }}"
+        description: "{{ item.value.description }}"
+        region: "{{ pod_spec.region }}"
+        rules: "{{ item.value.rules }}"
+        rules_egress: "{{ item.value.rules_egress }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+    when: do_create|bool
+    with_dict: "{{ pod_spec.security_groups }}"
+
+  - name: instances | terminate set | terminate
+    ec2:
+        instance_ids: "{{ terminate_set }}"
+        region: "{{ region }}"
+        state: absent
+        wait: yes
+        wait_timeout: 300 # five minutes
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+    ignore_errors: true
+    when: (terminate_set|length > 0)|bool
+
+  - name: instances | start set | start
+    ec2:
+        instance_ids: "{{ update_lists.start }}"
+        region: "{{ region }}"
+        state: running
+        wait: yes
+        wait_timeout: "{{ EC2_TIMEOUT }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+    when: ((do_create|bool) and (update_lists.start|length) > 0)|bool
+
+  - name: instances | create
+    ec2:
+        count_tag: "{{ item.value.count_tag }}"
+        exact_count: "{{ item.value.count }}"
+        group: "{{ item.value.group }}"
+        image: "{{ item.value.image }}"
+        instance_tags: "{{ item.value.count_tag }}"
+        instance_type: "{{ item.value.type }}"
+        key_name: "{{ item.value.ssh_key }}"
+        region: "{{ pod_spec.region }}"
+        volumes: "{{ item.value.volumes }}"
+        wait: yes
+        wait_timeout: "{{ EC2_TIMEOUT }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+    with_dict: "{{ pod_spec.instances }}"
+    when: do_create|bool
+    register: ec2_result
+
+  - name: instances | ein mapping | compute
+    set_fact:
+        ein_mapping: >
+            {{ ec2_result|compute_ec2_ein_mapping(pod_spec.region,
+                                                  aws_access_key_id,
+                                                  aws_secret_key) }}
+    when: do_create|bool
+
+# TODO(opadron): uncomment this section once we move to Ansible 2.0
+# See filter_plugins/ec2.py for other sections in need of updating.
+
+#  - name: instances | security groups | assign
+#    ec2_eni:
+#        eni_id: "{{ item.key }}"
+#        state: present
+#        security_groups: "{{ item.value }}"
+#        region: "{{ pod_spec.region }}"
+#        aws_access_key: "{{ aws_access_key_id }}"
+#        aws_secret_key: "{{ aws_secret_key }}"
+#    with_dict: "{{ ein_mapping }}"
+#    when: do_create|bool
+
+  - name: instances | collection | flatten
+    set_fact:
+        flattened_instances: >
+            {{ (ec2_result|flatten_ec2_result) if (do_create|bool) else [] }}
+
+  - name: instances | state | set
+    ec2:
+        instance_ids: "{{ flattened_instances|get_ec2_hosts }}"
+        region: "{{ region }}"
+        state: "{{ state }}"
+        wait: yes
+        wait_timeout: "{{ EC2_TIMEOUT }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+    when: do_create|bool
+
+  - name: instances | ansible groups | add
+    add_host:
+        hostname: "{{ item[options.ansible_groups_amend_mode] }}"
+        groups: "{{ item.groups | join(',') }}"
+    with_items: "{{ flattened_instances }}"
+    when: do_add|bool
+
+  - name: instances | ssh | wait
+    wait_for:
+        host: "{{ item }}"
+        port: 22
+        timeout: "{{ SSH_TIMEOUT }}"
+        state: started
+    with_items: >
+        {{ flattened_instances|get_ec2_wait_list(
+            options.ansible_groups_amend_mode) }}
+    when: do_wait|bool
+
+  - name: instances | elastic ips | associate
+    ec2_eip:
+        public_ip: "{{ item[0] }}"
+        instance_id: "{{ item[1] }}"
+        region: "{{ pod_spec.region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        state: present
+    with_items: "{{ flattened_instances|get_ec2_eips }}"
+    when: do_create|bool
+
+  - name: security groups | destroy
+    ec2_group:
+        name: "{{ item.key }}"
+        description: "{{ item.value.description }}"
+        region: "{{ pod_spec.region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        state: absent
+    when: do_destroy|bool
+    with_dict: "{{ pod_spec.security_groups }}"
+
+  - name: instances | ssh keys | destroy
+    ec2_key:
+        name: "{{ item.key }}"
+        region: "{{ pod_spec.region }}"
+        state: absent
+        wait: yes
+        wait_timeout: 300 # five minutes
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+    with_dict: "{{ pod_spec.ssh_keys }}"
+    when: do_destroy|bool
+

--- a/roles/ec2-pod2/vars/main.yml
+++ b/roles/ec2-pod2/vars/main.yml
@@ -1,0 +1,5 @@
+---
+
+    EC2_TIMEOUT: 1800 # 1/2 hour
+    SSH_TIMEOUT:  600 # 10 minutes
+


### PR DESCRIPTION
Provides an overhaul of the `ec2-pod` role.  New version has more features and can handle more use cases.  Note that due to the extensive changes, the original `ec2-pod` role has been preserved and this new role is temporarily referred to as `ec2-pod2`.

Some highlights of the improvements are:
- The role can now manage multiple, interlinked security groups.
- The role can now manage placement groups, making 10 Gbps links among instances possible.
- The role can now manage ssh keys, further reducing the need for prior setup in the AWS console.
- The role now uses a richer syntax extension to the `rules` and `rules_egress` syntax from the Ansible [ec2_group](http://docs.ansible.com/ansible/ec2_group_module.html) module.  This extension greatly reduces boilerplate when specifying complex traffic filtering criteria.
- The role includes a new templating mechanism that could greatly reduce boilerplate for pod specifications featuring many instances and/or security groups that share much of their configuration options.

This PR also introduces the new `aws-credentials` role, which greatly simplifies the process of specifying credentials for accessing AWS.  It includes support for profiles in a user's `./aws/credentials` file.  The `aws-credentials` role is designed to be used seamlessly with the new `ec2-pod2` role.

For more details on the new roles, see their documentation pages.
